### PR TITLE
Updated import paths to config.js in mobile-app api files

### DIFF
--- a/mobile-app/src/api/auth/loginAPI.js
+++ b/mobile-app/src/api/auth/loginAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "authentication/";
 
 class LoginAPI {

--- a/mobile-app/src/api/diet/dietGoalsAPI.js
+++ b/mobile-app/src/api/diet/dietGoalsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "dietGoals/";
 
 class DietGoalsAPI {

--- a/mobile-app/src/api/diet/foodEntriesAPI.js
+++ b/mobile-app/src/api/diet/foodEntriesAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "foodEntries/";
 
 class FoodEntriesAPI {

--- a/mobile-app/src/api/diet/foodItemsAPI.js
+++ b/mobile-app/src/api/diet/foodItemsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "foodItems/";
 
 class FoodItemsAPI {

--- a/mobile-app/src/api/fitness/exerciseEntriesAPI.js
+++ b/mobile-app/src/api/fitness/exerciseEntriesAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "exerciseEntries/";
 
 class ExerciseEntriesAPI {

--- a/mobile-app/src/api/fitness/exercisesAPI.js
+++ b/mobile-app/src/api/fitness/exercisesAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "exercise/";
 
 class ExercisesAPI {

--- a/mobile-app/src/api/fitness/workoutEntriesAPI.js
+++ b/mobile-app/src/api/fitness/workoutEntriesAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "workoutEntries/";
 
 class WorkoutEntriesAPI {

--- a/mobile-app/src/api/fitness/workoutPlansAPI.js
+++ b/mobile-app/src/api/fitness/workoutPlansAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "workoutPlans/";
 
 class WorkoutPlansAPI {

--- a/mobile-app/src/api/habits/habitStatusListAPI.js
+++ b/mobile-app/src/api/habits/habitStatusListAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "habitStatusList/";
 
 class HabitStatusListAPI {

--- a/mobile-app/src/api/habits/habitStatusesAPI.js
+++ b/mobile-app/src/api/habits/habitStatusesAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "habitStatuses/";
 
 class HabitStatusesAPI {

--- a/mobile-app/src/api/habits/habitsAPI.js
+++ b/mobile-app/src/api/habits/habitsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "habits/";
 
 class HabitsAPI {

--- a/mobile-app/src/api/mood/wellnessReportsAPI.js
+++ b/mobile-app/src/api/mood/wellnessReportsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "wellnessReports/";
 
 class WellnessReportsAPI {

--- a/mobile-app/src/api/notifications/notificationsHandler.js
+++ b/mobile-app/src/api/notifications/notificationsHandler.js
@@ -4,7 +4,7 @@ import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import axios from "axios";
 
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "notifications/";
 
 class NotificationsHandler {

--- a/mobile-app/src/api/sleep/sleepReportsAPI.js
+++ b/mobile-app/src/api/sleep/sleepReportsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "sleepReports/";
 
 class SleepReportsAPI {

--- a/mobile-app/src/api/stats/statsAPI.js
+++ b/mobile-app/src/api/stats/statsAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 
 class StatsAPI {
   static async getHabitStats(token, sunday) {

--- a/mobile-app/src/api/tasks/tasksAPI.js
+++ b/mobile-app/src/api/tasks/tasksAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "tasks/";
 
 class TasksAPI {

--- a/mobile-app/src/api/toDos/toDosAPI.js
+++ b/mobile-app/src/api/toDos/toDosAPI.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import moment from "moment";
 
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "toDos/";
 
 class ToDosAPI {

--- a/mobile-app/src/api/user/userAPI.js
+++ b/mobile-app/src/api/user/userAPI.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { EXPO_PUBLIC_BASE_URL } from "../config";
+import { EXPO_PUBLIC_BASE_URL } from "../../../config";
 const API = EXPO_PUBLIC_BASE_URL + "user/";
 
 class UserAPI {


### PR DESCRIPTION
Updated the paths to import EXPO_PUBLIC_BASE_URL from the config.js file in all of the files in the mobile-app/src/api folder that import it. 

This required a change from a reference path of `../config` (from when the file was also in the /api folder) to `../../../config` to reference its current location the in mobile-app folder. This results in the same one line change across many files. 