### PR TITLE
Typo and formatting fixes in account creation/login section

### DIFF
--- a/mobile-app/src/screens/Auth/CreateAccountLock.js
+++ b/mobile-app/src/screens/Auth/CreateAccountLock.js
@@ -143,7 +143,7 @@ const CreateAccountLock = (props) => {
           } else if (!data.isCorrectPassword) {
             setIsLoading(false);
             Toast.show(
-              "Incorrect password. This device already has an account",
+              "Incorrect password. This device already has an account.",
               {
                 ...styles.errorToast,
                 duration: Toast.durations.LONG,
@@ -155,7 +155,7 @@ const CreateAccountLock = (props) => {
             setIsLoading(false);
             Alert.alert(
               "Account Locked",
-              "Your account has been locked for security reasons. To unlock it, you must contact us",
+              "Your account has been locked for security reasons. To unlock it, you must contact us.",
               [{ text: "Ok" }],
               {
                 cancelable: true,

--- a/mobile-app/src/screens/Auth/CreateAccountLock.js
+++ b/mobile-app/src/screens/Auth/CreateAccountLock.js
@@ -143,7 +143,7 @@ const CreateAccountLock = (props) => {
           } else if (!data.isCorrectPassword) {
             setIsLoading(false);
             Toast.show(
-              "Incorrect password. This decvice already has an account",
+              "Incorrect password. This device already has an account",
               {
                 ...styles.errorToast,
                 duration: Toast.durations.LONG,
@@ -180,7 +180,7 @@ const CreateAccountLock = (props) => {
         }
       } else {
         setIsLoading(false);
-        Toast.show("Passwords do no match.", {
+        Toast.show("Passwords do not match.", {
           ...styles.errorToast,
           duration: Toast.durations.LONG,
           position: Toast.positions.CENTER,

--- a/mobile-app/src/screens/Auth/CreatePassword.js
+++ b/mobile-app/src/screens/Auth/CreatePassword.js
@@ -96,7 +96,7 @@ const CreatePassword = (props) => {
         }
       } else {
         setIsLoading(false);
-        Toast.show("Passwords do no match.", {
+        Toast.show("Passwords do not match.", {
           ...styles.errorToast,
           duration: Toast.durations.LONG,
           position: Toast.positions.CENTER,

--- a/mobile-app/src/screens/Auth/EnterCode.js
+++ b/mobile-app/src/screens/Auth/EnterCode.js
@@ -53,7 +53,7 @@ const EnterCode = (props) => {
           setIsLoading(false);
           Alert.alert(
             "Account Locked",
-            "Your account has been locked for security reasons. To unlock it, you must reset your password",
+            "Your account has been locked for security reasons. To unlock it, you must reset your password.",
             [
               { text: "Cancel", style: "cancel" },
               {

--- a/mobile-app/src/screens/Auth/EnterCode.js
+++ b/mobile-app/src/screens/Auth/EnterCode.js
@@ -79,14 +79,14 @@ const EnterCode = (props) => {
         } else if (data?.loginFailed == "incorrectOTP") {
           setIsLoading(false);
           setShowBottomText(true);
-          Toast.show("Invalid Code", {
+          Toast.show("Invalid Code.", {
             ...styles.errorToast,
             duration: Toast.durations.LONG,
           });
         } else if (data?.loginFailed == "expired") {
           setIsLoading(false);
           setShowBottomText(true);
-          Toast.show("Code has expired", {
+          Toast.show("Code has expired.", {
             ...styles.errorToast,
             duration: Toast.durations.LONG,
           });
@@ -137,7 +137,7 @@ const EnterCode = (props) => {
       }
     } else {
       setIsLoading(false);
-      Toast.show("Invalid Code", {
+      Toast.show("Invalid Code.", {
         ...styles.errorToast,
         duration: Toast.durations.LONG,
       });

--- a/mobile-app/src/screens/Auth/TempPassword.js
+++ b/mobile-app/src/screens/Auth/TempPassword.js
@@ -54,7 +54,7 @@ const EnterPassword = (props) => {
           setTempPassword("");
           Alert.alert(
             "Account Locked",
-            "Your account has been locked for security reasons. To unlock it, you must reset your password",
+            "Your account has been locked for security reasons. To unlock it, you must reset your password.",
             [
               { text: "Cancel", style: "cancel" },
               {
@@ -81,7 +81,7 @@ const EnterPassword = (props) => {
           setIsLoading(false);
           Alert.alert(
             "Oasis Account Suspended",
-            "Your account has been suspended for security reasons. To unlock it, you must contact us",
+            "Your account has been suspended for security reasons. To unlock it, you must contact us.",
             [{ text: "Ok" }],
             {
               cancelable: true,
@@ -96,7 +96,7 @@ const EnterPassword = (props) => {
         }
       } else {
         setIsLoading(false);
-        Toast.show("Something went wrong. Please try again", {
+        Toast.show("Something went wrong. Please try again.", {
           ...styles.errorToast,
           duration: Toast.durations.LONG,
         });

--- a/mobile-app/src/screens/Auth/UnlockAccount.js
+++ b/mobile-app/src/screens/Auth/UnlockAccount.js
@@ -132,7 +132,7 @@ const UnlockAccount = (props) => {
           setIsLoading(false);
           Alert.alert(
             "Account Locked",
-            "Your account has been locked for security reasons. To unlock it, you must contact us",
+            "Your account has been locked for security reasons. To unlock it, you must contact us.",
             [{ text: "Ok" }],
             {
               cancelable: true,


### PR DESCRIPTION
Fixed toast message typos in CreateAccountLock.js and CreatePassword.js, as well as added periods to the messages in other files of the mobile-app/src/screens/Auth folder for consistency across the messages. 

Passwords not matching message - before the change:
![passwords message before](https://github.com/user-attachments/assets/bf91abb8-ff13-4015-8456-88f536b31e5c)
Passwords not matching message - after the change: 
![passwords message after](https://github.com/user-attachments/assets/f4dcc682-4fca-471b-90ac-476cd133bf33)
