### PR TITLE
UI updates to meal page - add food button and scroll view

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -5,6 +5,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  ScrollView
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "react-native";
@@ -46,41 +47,46 @@ const MealPage = (props) => {
                 </View>
             </View>
             <View style={styles.mainArea}> 
-                <View style={styles.buttonSection}>
-                    <TouchableOpacity style={styles.addFood}>
-                        <Text style={styles.addFoodText}>Add Food</Text>
-                    </TouchableOpacity>
-                </View>
-                <TouchableOpacity style={styles.calories}>
-                    <Image style={styles.mealIcon} source={require("../../../assets/images/calories.png")}></Image>
-                    <View style={styles.calorieText}>
-                        <Text style={styles.caloriesLabel}>Calories</Text>
-                        <View style={styles.calorieInfo}>                        
-                            <Text style={styles.caloriesAmount}>99999</Text>
-                            <Text style={styles.caloriesUnit}>kcal</Text>
-                        </View>
-                    </View>
-                </TouchableOpacity>
-                <View style={styles.macroSection}>
-                    <TouchableOpacity style={styles.macros}>
-                        <Image style={styles.macroIcon} source={require("../../../assets/images/carbs.png")}></Image>
-                        <Text style={styles.textStyle}>Carbs</Text>
-                        <Text style={styles.macroAmount}>0</Text>
-                        <Text style={styles.macroUnit}>g</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity style={styles.macros}>
-                        <Image style={styles.macroIcon} source={require("../../../assets/images/protein.png")}></Image>
-                        <Text style={styles.textStyle}>Protein</Text>
-                        <Text style={styles.macroAmount}>0</Text>
-                        <Text style={styles.macroUnit}>g</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity style={styles.macros}>
-                        <Image style={styles.macroIcon} source={require("../../../assets/images/fats.png")}></Image>
-                        <Text style={styles.textStyle}>Fats</Text>
-                        <Text style={styles.macroAmount}>0</Text>
-                        <Text style={styles.macroUnit}>g</Text>
-                    </TouchableOpacity>
-                </View>
+              <ScrollView
+                    showsVerticalScrollIndicator={false}
+                    contentContainerStyle={styles.scrollContainer}
+                  >
+                  <View style={styles.buttonSection}>
+                      <TouchableOpacity style={styles.addFood}>
+                          <Text style={styles.addFoodText}>Add Food</Text>
+                      </TouchableOpacity>
+                  </View>
+                  <TouchableOpacity style={styles.calories}>
+                      <Image style={styles.mealIcon} source={require("../../../assets/images/calories.png")}></Image>
+                      <View style={styles.calorieText}>
+                          <Text style={styles.caloriesLabel}>Calories</Text>
+                          <View style={styles.calorieInfo}>                        
+                              <Text style={styles.caloriesAmount}>99999</Text>
+                              <Text style={styles.caloriesUnit}>kcal</Text>
+                          </View>
+                      </View>
+                  </TouchableOpacity>
+                  <View style={styles.macroSection}>
+                      <TouchableOpacity style={styles.macros}>
+                          <Image style={styles.macroIcon} source={require("../../../assets/images/carbs.png")}></Image>
+                          <Text style={styles.textStyle}>Carbs</Text>
+                          <Text style={styles.macroAmount}>0</Text>
+                          <Text style={styles.macroUnit}>g</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity style={styles.macros}>
+                          <Image style={styles.macroIcon} source={require("../../../assets/images/protein.png")}></Image>
+                          <Text style={styles.textStyle}>Protein</Text>
+                          <Text style={styles.macroAmount}>0</Text>
+                          <Text style={styles.macroUnit}>g</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity style={styles.macros}>
+                          <Image style={styles.macroIcon} source={require("../../../assets/images/fats.png")}></Image>
+                          <Text style={styles.textStyle}>Fats</Text>
+                          <Text style={styles.macroAmount}>0</Text>
+                          <Text style={styles.macroUnit}>g</Text>
+                      </TouchableOpacity>
+                  </View>
+                </ScrollView>
             </View>            
         </SafeAreaView>
     );
@@ -91,6 +97,10 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     justifyContent: "space-between",
+  },
+  scrollContainer: {
+    overflow: "visible",
+    paddingBottom: 30,
   },
   topArea: {
     backgroundColor: "#D7F6FF",


### PR DESCRIPTION
This PR consists of two changes to the meal page layout: 

1. The "add food" button has been moved to be above the meal page macro summary, in accordance with a design update. 

Figma design screenshot:
![meal page figma](https://github.com/user-attachments/assets/7948a47b-1325-45da-814a-fa04645ffd59)
App UI screenshot:
![add button moved](https://github.com/user-attachments/assets/32583649-cc6b-4940-9491-37576e067b6c)
2. The main body of the meal page has been enclosed within a scroll view to facilitate the addition of meal items in a future PR. The contents of the page are expected to be able to exceed the space provided in the main body of the page, so a scroll view will be needed to ensure all contents of the page are accessible. The top area (blue banner) of the page is outside of the scroll view and remains constant when the scrolling occurs. No scrolling can be done when the components on the page do not exceed the available space, so for illustration and confirmation of the scroll view working as intended, several "add food" buttons were added temporarily - these were removed prior to committing any changes. 

https://github.com/user-attachments/assets/107cf9a1-8c2d-46bb-8cfa-c80c280a9979


