### PR TITLE
Creation of a static meal item component

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -5,7 +5,8 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  ScrollView
+  ScrollView,
+  Alert
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "react-native";
@@ -38,8 +39,24 @@ const MealPage = (props) => {
   };
 
   const deleteMealItem = (id) => {
-    const updatedMealItems = mealItems.filter((item) => item.id !== id);
-    setMealItems(updatedMealItems);
+    Alert.alert(
+      "Delete Meal Item",
+      "Are you sure you want to delete this meal item?",
+      [
+        { text: "No", style: "cancel" },
+        {
+          text: "Yes",
+          isPreferred: true,
+          onPress: () => {
+            const updatedMealItems = mealItems.filter((item) => item.id !== id);
+            setMealItems(updatedMealItems);
+          },
+        },
+      ],
+      {
+        cancelable: true,
+      }
+    );
   };
 
     return (


### PR DESCRIPTION
Added a meal item component section to the meal page, between the blue top area and the "add food" button. This section can hold any amount of meal items, from 0 (empty area) to 1 or more. 

Pressing the "add food" button adds a sample meal item to a local array and displays an additional meal item on the meal page. Currently the meal items of a page carry across meals; e.g. a meal item added on a breakfast page will also appear on the lunch page. 

Pressing on the trash bin icon on the meal item component will bring up an alert asking for confirmation on the deletion of the item. If the user selects "no", the alert is dismissed and the item remains; if they select "yes", the alert is dismissed and the selected meal item is deleted. This carries over between meal pages currently - deleting an item on a dinner page means it also won't appear on the snack page. 

See the screen recording attached at the end for a view of the behaviour. 

Figma designs:
![meal page figma with meal item](https://github.com/user-attachments/assets/333b1287-319c-489a-b728-22360f52753e)
![meal page figma](https://github.com/user-attachments/assets/3bfa8873-f812-4ebd-88e7-2aad21b103b1)

UI with 0 meal items:
![meal item static none - Copy](https://github.com/user-attachments/assets/a97008cf-73aa-4b97-bf18-7e374bddbeb6)

UI with 1 meal item:
![meal item static single - Copy](https://github.com/user-attachments/assets/ec4e8034-b650-4212-89f1-7e191d1d4ca6)

UI with multiple meal items: 
![meal item static multiple - Copy](https://github.com/user-attachments/assets/90fc024a-7afc-4d19-8027-2aa3fa55ce4e)

Screen recording of behaviour:

https://github.com/user-attachments/assets/dfc96f92-c4bd-4805-8872-fd0ea2e20f1e