### PR TITLE
Add progress to marco circles displayed on diet page

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -57,8 +57,7 @@ export default function Diet({
   deleteFoodEntry
 }) {
   const calorieDif = dietGoals.calorieGoal.value- totalMacros.calorieCount ;
-  const consumedPercent = `${(totalMacros.calorieCount / dietGoals.calorieGoal.value * 100).toFixed(0)}%`;
-  const circleColours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
+  const colours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
 
   const EmptyMeal = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} 
@@ -110,12 +109,11 @@ export default function Diet({
     var innerColor;
     var outerColor;
     if(percentage>3){
-      innerColor = circleColours[3];
-      outerColor = circleColours[3];
+      innerColor = colours[3];
+      outerColor = colours[3];
     }else{
-
-      innerColor = circleColours[index];
-      outerColor = circleColours[index+1]
+      innerColor = colours[index];
+      outerColor = colours[index+1]
     }
     return (
     <View >
@@ -137,6 +135,27 @@ export default function Diet({
       </View>
     </View>
   )};
+
+  const CalorieBar = () => {
+    var percentage= totalMacros.calorieCount / dietGoals.calorieGoal.value;
+    var consumedPercent = `${( (percentage%1)* 100).toFixed(0)}%`;
+    var index= Math.floor(percentage);
+    var innerColor;
+    var outerColor;
+    if(percentage>3){
+      innerColor = colours[3];
+      outerColor = colours[3];
+    }else{
+      innerColor = colours[index];
+      outerColor = colours[index+1]
+    }
+
+    return (
+      <View style={[styles.progress, {backgroundColor: innerColor, borderColor: innerColor}]}>
+        <View style={[styles.filler, {width: consumedPercent, backgroundColor: outerColor},]}/>
+      </View>
+    )
+  }
 
   return (
     <ScrollView
@@ -212,10 +231,7 @@ export default function Diet({
           </Text>
           <Text style={styles.boldText}>{Math.abs(calorieDif)}</Text>
         </View>
-
-        <View style={styles.progress}>
-          <View style={[styles.filler, {width: consumedPercent,},]}/>
-        </View>
+        <CalorieBar />
         <View style={[styles.row, { gap: 10 }]}>
           {macroKeys.map((item, index) => (
             <View style={styles.item} key={index}>
@@ -348,8 +364,6 @@ const styles = StyleSheet.create({
   progress: {
     height: 20,
     borderWidth: 2,
-    borderColor: "#ACC5CC",
-    backgroundColor: "#ACC5CC",
     borderRadius: 5,
     marginBottom: 50,
   },

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -111,6 +111,16 @@ export default function Diet({
         </Text>
         <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
       </View>
+      <View style={styles.progressCirlceContent}>
+        <Progress.Circle
+          progress={(totalMacros[item.consumed]/dietGoals[item.goal])-1} 
+          strokeCap="round" 
+          size={93} 
+          thickness={9}
+          color={(totalMacros[item.consumed]/dietGoals[item.goal])-1 >0 ? "#76BBCF" : "rgba(0,0,0,0)"}
+          borderWidth={0}
+        />
+      </View>
       
     </View>
   );

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -101,9 +101,8 @@ export default function Diet({
         size={93} 
         thickness={9}
         unfilledColor="#B3B3B3"
-        color="#D7F6FF"
-        borderWidth={1}
-        borderColor="#B3B3B3"
+        color="#25436B"
+        borderWidth={0}
       />
       <View style = {styles.progressCirlceContent}>
         <Text style={[ styles.boldText, {fontSize: 22,}]}>

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -11,6 +11,7 @@ import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
 import * as Progress from 'react-native-progress';
+import Svg, { Circle } from 'react-native-svg';
 
 const mealTitles = [
   {
@@ -100,15 +101,28 @@ export default function Diet({
         strokeCap="round" 
         size={93} 
         thickness={9}
-        unfilledColor="#B3B3B3"
-        color="#25436B"
-        borderWidth={0}
+        unfilledColor="#DEDEDE"
+        color="#D7F6FF"
+        borderWidth={2}
+        borderColor="#B3B3B3"
       />
       <View style = {styles.progressCirlceContent}>
         <Text style={[ styles.boldText, {fontSize: 22,}]}>
           {totalMacros[item.consumed]}g
         </Text>
         <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
+      </View>
+      <View style={styles.progressCirlceContent}>
+        <Svg>
+          <Circle
+            cx="48.2%"
+            cy="50%"
+            r="37"
+            stroke="#B3B3B3"
+            strokeWidth="2"
+            fill="transparent"
+          />
+        </Svg>
       </View>
       
     </View>

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -10,7 +10,7 @@ import React from "react";
 import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
-import * as Progress from 'react-native-progress';
+import * as Progress from "react-native-progress";
 
 const mealTitles = [
   {
@@ -47,25 +47,29 @@ const macroKeys = [
 
 const today = new Date();
 
-
 export default function Diet({
   day,
   updateDate,
   meals,
   dietGoals,
   totalMacros,
-  deleteFoodEntry
+  deleteFoodEntry,
 }) {
-  const calorieDif = dietGoals.calorieGoal.value- totalMacros.calorieCount ;
-  const colours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
+  const calorieDif = dietGoals.calorieGoal.value - totalMacros.calorieCount;
+  const colours = ["#ACC5CC", "#D7F6FF", "#76BBCF", "#008ab3"];
 
   const EmptyMeal = ({ item }) => (
-    <TouchableOpacity style={styles.borderedContainer} 
-      onPress={() => { navigationService.navigate("mealPage", { 
-        mealName: item.name, 
-        meal: meals[item.name],
-        deleteFoodEntry: deleteFoodEntry}) }}>
-      <View style={[styles.row, {marginBottom: 0}]}>
+    <TouchableOpacity
+      style={styles.borderedContainer}
+      onPress={() => {
+        navigationService.navigate("mealPage", {
+          mealName: item.name,
+          meal: meals[item.name],
+          deleteFoodEntry: deleteFoodEntry,
+        });
+      }}
+    >
+      <View style={[styles.row, { marginBottom: 0 }]}>
         <Text style={styles.itemText}>{item?.name}</Text>
         <TouchableOpacity>
           <Image
@@ -78,11 +82,16 @@ export default function Diet({
   );
 
   const MealWithEntries = ({ item }) => (
-    <TouchableOpacity style={styles.borderedContainer} 
-      onPress={() => { navigationService.navigate("mealPage", { 
-        mealName: item.name, 
-        meal: meals[item.name],
-        deleteFoodEntry: deleteFoodEntry}) }}>      
+    <TouchableOpacity
+      style={styles.borderedContainer}
+      onPress={() => {
+        navigationService.navigate("mealPage", {
+          mealName: item.name,
+          meal: meals[item.name],
+          deleteFoodEntry: deleteFoodEntry,
+        });
+      }}
+    >
       <View style={styles.row}>
         <Text style={styles.itemText}>{item.name}</Text>
         <TouchableOpacity>
@@ -93,69 +102,86 @@ export default function Diet({
         </TouchableOpacity>
       </View>
       {meals[item.name].entries.map((item, index) => (
-        <View style={[styles.row, {marginBottom: 4}]} key={index}>
-          <Text style={styles.subItemText} >{item.name}</Text>
-          <Text style={styles.subItemText}>{item.calorieCount} {dietGoals.calorieGoal.units}</Text>
+        <View style={[styles.row, { marginBottom: 4 }]} key={index}>
+          <Text style={styles.subItemText}>{item.name}</Text>
+          <Text style={styles.subItemText}>
+            {item.calorieCount} {dietGoals.calorieGoal.units}
+          </Text>
         </View>
       ))}
       <View style={styles.line} />
-      <Text style={[styles.subItemText, { textAlign: "center", }]}>{meals[item.name].calorieCount} {dietGoals.calorieGoal.units}</Text>
+      <Text style={[styles.subItemText, { textAlign: "center" }]}>
+        {meals[item.name].calorieCount} {dietGoals.calorieGoal.units}
+      </Text>
     </TouchableOpacity>
   );
 
-  const MacroProgressCircle = ({item}) => {
-    var percentage= (totalMacros[item.consumed]/dietGoals[item.goal]).toFixed(1);
-    var index= Math.floor(percentage);
+  const MacroProgressCircle = ({ item }) => {
+    var percentage = (
+      totalMacros[item.consumed] / dietGoals[item.goal]
+    ).toFixed(1);
+    var index = Math.floor(percentage);
     var innerColor;
     var outerColor;
-    if(percentage>3){
+    if (percentage > 3) {
       innerColor = colours[3];
       outerColor = colours[3];
-    }else{
+    } else {
       innerColor = colours[index];
-      outerColor = colours[index+1]
+      outerColor = colours[index + 1];
     }
     return (
-    <View >
-      <Progress.Circle 
-        progress={percentage%1} 
-        strokeCap="round" 
-        size={93} 
-        thickness={9}
-        unfilledColor={innerColor}
-        color={outerColor}
-        borderWidth={1}
-        borderColor="#ACC5CC"
-      />
-      <View style = {styles.progressCirlceContent}>
-        <Text style={[ styles.boldText, {fontSize: 22,}]}>
-          {totalMacros[item.consumed]}g
-        </Text>
-        <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
+      <View>
+        <Progress.Circle
+          progress={percentage % 1}
+          strokeCap="round"
+          size={93}
+          thickness={9}
+          unfilledColor={innerColor}
+          color={outerColor}
+          borderWidth={1}
+          borderColor="#ACC5CC"
+        />
+        <View style={styles.progressCirlceContent}>
+          <Text style={[styles.boldText, { fontSize: 22 }]}>
+            {totalMacros[item.consumed]}g
+          </Text>
+          <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
+        </View>
       </View>
-    </View>
-  )};
+    );
+  };
 
   const CalorieBar = () => {
-    var percentage= totalMacros.calorieCount / dietGoals.calorieGoal.value;
-    var consumedPercent = `${( (percentage%1)* 100).toFixed(0)}%`;
-    var index= Math.floor(percentage);
+    var percentage = totalMacros.calorieCount / dietGoals.calorieGoal.value;
+    var consumedPercent = `${((percentage % 1) * 100).toFixed(0)}%`;
+    var index = Math.floor(percentage);
     var innerColor;
     var outerColor;
-    if(percentage>3){
+    if (percentage > 3) {
       innerColor = colours[3];
       outerColor = colours[3];
-    }else{
+    } else {
       innerColor = colours[index];
-      outerColor = colours[index+1]
+      outerColor = colours[index + 1];
     }
 
     return (
-      <View style={[styles.progress, {backgroundColor: innerColor, borderColor: innerColor}]}>
-        <View style={[styles.filler, {width: consumedPercent, backgroundColor: outerColor},]}/>
+      <View
+        style={[
+          styles.progress,
+          { backgroundColor: innerColor, borderColor: innerColor },
+        ]}
+      >
+        <View
+          style={[
+            styles.filler,
+            { width: consumedPercent, backgroundColor: outerColor },
+          ]}
+        />
       </View>
-    )
-  }
+    );
+  };
 
   return (
     <ScrollView
@@ -179,7 +205,6 @@ export default function Diet({
         </View>
       </View>
 
-
       <View style={sharedStyles.datePickerView}>
         <TouchableOpacity
           style={sharedStyles.changeDateButton}
@@ -192,7 +217,7 @@ export default function Diet({
         </TouchableOpacity>
         <>
           {moment(day).format("YYYYMMDD") ==
-            moment(today).format("YYYYMMDD") ? (
+          moment(today).format("YYYYMMDD") ? (
             <Text style={sharedStyles.dateText}>Today</Text>
           ) : (
             <Text style={sharedStyles.dateText}>
@@ -223,7 +248,9 @@ export default function Diet({
         </View>
         <View style={styles.row}>
           <Text style={styles.miniText}>Eaten</Text>
-          <Text style={styles.miniText}>{calorieDif>0? "Remaining" : "Exceeded"}</Text>
+          <Text style={styles.miniText}>
+            {calorieDif > 0 ? "Remaining" : "Exceeded"}
+          </Text>
         </View>
         <View style={styles.row}>
           <Text style={styles.desc}>
@@ -240,16 +267,15 @@ export default function Diet({
             </View>
           ))}
         </View>
-      </View> 
-      
+      </View>
 
-      {mealTitles.map((item, index) => (
+      {mealTitles.map((item, index) =>
         meals[item.name].entries.length > 0 ? (
           <MealWithEntries item={item} key={index} />
         ) : (
           <EmptyMeal item={item} key={index} />
         )
-      ))}
+      )}
     </ScrollView>
   );
 }
@@ -399,16 +425,16 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   progressCirlceContent: {
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
   },
   line: {
-    borderBottomColor: '#ccc',
+    borderBottomColor: "#ccc",
     borderBottomWidth: 1,
     marginVertical: 10,
   },

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -10,6 +10,7 @@ import React from "react";
 import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
+import * as Progress from 'react-native-progress';
 
 const mealTitles = [
   {
@@ -90,6 +91,28 @@ export default function Diet({
       <View style={styles.line} />
       <Text style={[styles.subItemText, { textAlign: "center", }]}>{meals[item.name].calorieCount} {dietGoals.calorieGoal.units}</Text>
     </TouchableOpacity>
+  );
+
+  const MacroProgressCircle = ({item}) => (
+    <View >
+      <Progress.Circle 
+        progress={totalMacros[item.consumed]/dietGoals[item.goal]} 
+        strokeCap="round" 
+        size={93} 
+        thickness={9}
+        unfilledColor="#B3B3B3"
+        color="#D7F6FF"
+        borderWidth={1}
+        borderColor="#B3B3B3"
+      />
+      <View style = {styles.progressCirlceContent}>
+        <Text style={[ styles.boldText, {fontSize: 22,}]}>
+          {totalMacros[item.consumed]}g
+        </Text>
+        <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
+      </View>
+      
+    </View>
   );
 
   return (
@@ -173,23 +196,13 @@ export default function Diet({
         <View style={[styles.row, { gap: 10 }]}>
           {macroKeys.map((item, index) => (
             <View style={styles.item} key={index}>
-              <View style={styles.round}>
-                <Text style={[
-                  styles.boldText,
-                  {
-                    fontSize: 24,
-                  }
-                ]}
-                >
-                  {totalMacros[item.consumed]}g
-                </Text>
-                <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
-              </View>
+              <MacroProgressCircle item={item} />
               <Text style={styles.desc}>{item.title}</Text>
             </View>
           ))}
         </View>
-      </View>
+      </View> 
+      
 
       {mealTitles.map((item, index) => (
         meals[item.name].entries.length > 0 ? (
@@ -348,14 +361,14 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
   },
-  round: {
-    width: "100%",
-    aspectRatio: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    borderWidth: 8,
-    borderColor: "#B3B3B3",
-    borderRadius: 100,
+  progressCirlceContent: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   line: {
     borderBottomColor: '#ccc',

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -56,6 +56,7 @@ export default function Diet({
   totalMacros
 }) {
   const consumedPercent = `${(totalMacros.calorieCount / dietGoals.calorieGoal.value * 100).toFixed(0)}%`;
+  const circleColours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
 
   const EmptyMeal = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} onPress={() => { navigationService.navigate("mealPage", { mealName: item.name }) }}>
@@ -93,15 +94,31 @@ export default function Diet({
     </TouchableOpacity>
   );
 
-  const MacroProgressCircle = ({item}) => (
+  const MacroProgressCircle = ({item}) => {
+    var percentage= totalMacros[item.consumed]/dietGoals[item.goal];
+    var index= Math.floor(percentage);
+    var innerColor;
+    var outerColor;
+    if(percentage>=3){
+      innerColor = circleColours[2];
+      outerColor = circleColours[3];
+    }else{
+
+      innerColor = circleColours[index];
+      outerColor = circleColours[index+1]
+    }
+
+    if(percentage>=4)
+      percentage=4;
+    return (
     <View >
       <Progress.Circle 
-        progress={totalMacros[item.consumed]/dietGoals[item.goal]} 
+        progress={percentage%1} 
         strokeCap="round" 
         size={93} 
         thickness={9}
-        unfilledColor="#ACC5CC"
-        color="#D7F6FF"
+        unfilledColor={innerColor}
+        color={outerColor}
         borderWidth={1}
         borderColor="#ACC5CC"
       />
@@ -111,19 +128,8 @@ export default function Diet({
         </Text>
         <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
       </View>
-      <View style={styles.progressCirlceContent}>
-        <Progress.Circle
-          progress={(totalMacros[item.consumed]/dietGoals[item.goal])-1} 
-          strokeCap="round" 
-          size={93} 
-          thickness={9}
-          color={(totalMacros[item.consumed]/dietGoals[item.goal])-1 >0 ? "#76BBCF" : "rgba(0,0,0,0)"}
-          borderWidth={0}
-        />
-      </View>
-      
     </View>
-  );
+  )};
 
   return (
     <ScrollView

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -11,7 +11,6 @@ import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
 import * as Progress from 'react-native-progress';
-import * as Progress from 'react-native-progress';
 
 const mealTitles = [
   {
@@ -57,6 +56,7 @@ export default function Diet({
   totalMacros,
   deleteFoodEntry
 }) {
+  const calorieDif = dietGoals.calorieGoal.value- totalMacros.calorieCount ;
   const consumedPercent = `${(totalMacros.calorieCount / dietGoals.calorieGoal.value * 100).toFixed(0)}%`;
   const circleColours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
 
@@ -204,13 +204,13 @@ export default function Diet({
         </View>
         <View style={styles.row}>
           <Text style={styles.miniText}>Eaten</Text>
-          <Text style={styles.miniText}>Remaining</Text>
+          <Text style={styles.miniText}>{calorieDif>0? "Remaining" : "Exceeded"}</Text>
         </View>
         <View style={styles.row}>
           <Text style={styles.desc}>
             <Text style={styles.boldText}>{totalMacros.calorieCount}</Text> kcal
           </Text>
-          <Text style={styles.boldText}>{dietGoals.calorieGoal.value - totalMacros.calorieCount}</Text>
+          <Text style={styles.boldText}>{Math.abs(calorieDif)}</Text>
         </View>
 
         <View style={styles.progress}>

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -11,7 +11,6 @@ import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
 import * as Progress from 'react-native-progress';
-import Svg, { Circle } from 'react-native-svg';
 
 const mealTitles = [
   {

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -101,28 +101,16 @@ export default function Diet({
         strokeCap="round" 
         size={93} 
         thickness={9}
-        unfilledColor="#DEDEDE"
+        unfilledColor="#ACC5CC"
         color="#D7F6FF"
-        borderWidth={2}
-        borderColor="#B3B3B3"
+        borderWidth={1}
+        borderColor="#ACC5CC"
       />
       <View style = {styles.progressCirlceContent}>
         <Text style={[ styles.boldText, {fontSize: 22,}]}>
           {totalMacros[item.consumed]}g
         </Text>
         <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
-      </View>
-      <View style={styles.progressCirlceContent}>
-        <Svg>
-          <Circle
-            cx="48.2%"
-            cy="50%"
-            r="37"
-            stroke="#B3B3B3"
-            strokeWidth="2"
-            fill="transparent"
-          />
-        </Svg>
       </View>
       
     </View>
@@ -339,7 +327,7 @@ const styles = StyleSheet.create({
     height: 20,
     borderWidth: 2,
     borderColor: "#ACC5CC",
-    backgroundColor: "#E4CCFF",
+    backgroundColor: "#ACC5CC",
     borderRadius: 5,
     marginBottom: 50,
   },

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -95,21 +95,18 @@ export default function Diet({
   );
 
   const MacroProgressCircle = ({item}) => {
-    var percentage= totalMacros[item.consumed]/dietGoals[item.goal];
+    var percentage= (totalMacros[item.consumed]/dietGoals[item.goal]).toFixed(1);
     var index= Math.floor(percentage);
     var innerColor;
     var outerColor;
-    if(percentage>=3){
-      innerColor = circleColours[2];
+    if(percentage>3){
+      innerColor = circleColours[3];
       outerColor = circleColours[3];
     }else{
 
       innerColor = circleColours[index];
       outerColor = circleColours[index+1]
     }
-
-    if(percentage>=4)
-      percentage=4;
     return (
     <View >
       <Progress.Circle 
@@ -348,7 +345,7 @@ const styles = StyleSheet.create({
   },
   filler: {
     backgroundColor: "#D7F6FF",
-    width: "70%",
+    maxWidth: "100%",
     height: "100%",
   },
   row: {

--- a/mobile-app/src/screens/Fitness-Diet/Main.js
+++ b/mobile-app/src/screens/Fitness-Diet/Main.js
@@ -22,7 +22,28 @@ export default function Main({
   setDietModalVisible,
 }) {
   const today = new Date();
-  const consumedPercent = `${(totalMacros.calorieCount/dietGoals.calorieGoal.value*100).toFixed(0)}%`;
+  const colours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
+
+    const CalorieBar = () => {
+      var percentage= totalMacros.calorieCount / dietGoals.calorieGoal.value;
+      var consumedPercent = `${( (percentage%1)* 100).toFixed(0)}%`;
+      var index= Math.floor(percentage);
+      var innerColor;
+      var outerColor;
+      if(percentage>3){
+        innerColor = colours[3];
+        outerColor = colours[3];
+      }else{
+        innerColor = colours[index];
+        outerColor = colours[index+1]
+      }
+  
+      return (
+        <View style={[styles.progress, {backgroundColor: innerColor, borderColor: innerColor}]}>
+          <View style={[styles.filler, {width: consumedPercent, backgroundColor: outerColor},]}/>
+        </View>
+      )
+    }
 
   return (
     <ScrollView
@@ -87,15 +108,7 @@ export default function Main({
               source={require("../../assets/images/add-food.png")}
             />
           </TouchableOpacity>
-          <View style={styles.progress}>
-            <View style={[
-                styles.filler,
-                { 
-                  width: consumedPercent,
-                },
-              ]} 
-            />
-          </View>
+          <CalorieBar/>
           <Text style={styles.desc}>
             <Text style={styles.boldText}>{totalMacros["calorieCount"]}</Text> / {dietGoals["calorieGoal"]["value"]} {dietGoals["calorieGoal"]["units"]}
           </Text>

--- a/mobile-app/src/screens/Fitness-Diet/Main.js
+++ b/mobile-app/src/screens/Fitness-Diet/Main.js
@@ -205,7 +205,7 @@ const styles = StyleSheet.create({
   },
   filler: {
     backgroundColor: "#D7F6FF",
-    width: "70%",
+    maxWidth: "100%",
     height: "100%",
   },
 });

--- a/mobile-app/src/screens/Fitness-Diet/Main.js
+++ b/mobile-app/src/screens/Fitness-Diet/Main.js
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
     width: 350,
     borderWidth: 2,
     borderColor: "#ACC5CC",
-    backgroundColor: "#E4CCFF",
+    backgroundColor: "#ACC5CC",
     marginHorizontal: 30,
     borderRadius: 5,
     marginBottom: 10,

--- a/mobile-app/src/screens/Fitness-Diet/Main.js
+++ b/mobile-app/src/screens/Fitness-Diet/Main.js
@@ -11,39 +11,49 @@ import { sharedStyles } from "../styles";
 import moment from "moment";
 import Spinner from "react-native-loading-spinner-overlay";
 
-export default function Main({ 
+export default function Main({
   day,
-  trackingPreferences, 
+  trackingPreferences,
   isLoading = false,
-  updateDate, 
+  updateDate,
   meals,
-  totalMacros, 
+  totalMacros,
   dietGoals,
   setDietModalVisible,
 }) {
   const today = new Date();
-  const colours = ["#ACC5CC","#D7F6FF","#76BBCF","#008ab3"];
+  const colours = ["#ACC5CC", "#D7F6FF", "#76BBCF", "#008ab3"];
 
-    const CalorieBar = () => {
-      var percentage= totalMacros.calorieCount / dietGoals.calorieGoal.value;
-      var consumedPercent = `${( (percentage%1)* 100).toFixed(0)}%`;
-      var index= Math.floor(percentage);
-      var innerColor;
-      var outerColor;
-      if(percentage>3){
-        innerColor = colours[3];
-        outerColor = colours[3];
-      }else{
-        innerColor = colours[index];
-        outerColor = colours[index+1]
-      }
-  
-      return (
-        <View style={[styles.progress, {backgroundColor: innerColor, borderColor: innerColor}]}>
-          <View style={[styles.filler, {width: consumedPercent, backgroundColor: outerColor},]}/>
-        </View>
-      )
+  const CalorieBar = () => {
+    var percentage = totalMacros.calorieCount / dietGoals.calorieGoal.value;
+    var consumedPercent = `${((percentage % 1) * 100).toFixed(0)}%`;
+    var index = Math.floor(percentage);
+    var innerColor;
+    var outerColor;
+    if (percentage > 3) {
+      innerColor = colours[3];
+      outerColor = colours[3];
+    } else {
+      innerColor = colours[index];
+      outerColor = colours[index + 1];
     }
+
+    return (
+      <View
+        style={[
+          styles.progress,
+          { backgroundColor: innerColor, borderColor: innerColor },
+        ]}
+      >
+        <View
+          style={[
+            styles.filler,
+            { width: consumedPercent, backgroundColor: outerColor },
+          ]}
+        />
+      </View>
+    );
+  };
 
   return (
     <ScrollView
@@ -102,15 +112,22 @@ export default function Main({
           <View style={[sharedStyles.trackerDashView]}>
             <Text style={sharedStyles.trackerTitle}>Diet</Text>
           </View>
-          <TouchableOpacity style={styles.addBtn} onPress={()=>{setDietModalVisible(true)}}>
+          <TouchableOpacity
+            style={styles.addBtn}
+            onPress={() => {
+              setDietModalVisible(true);
+            }}
+          >
             <Image
               style={styles.plus}
               source={require("../../assets/images/add-food.png")}
             />
           </TouchableOpacity>
-          <CalorieBar/>
+          <CalorieBar />
           <Text style={styles.desc}>
-            <Text style={styles.boldText}>{totalMacros["calorieCount"]}</Text> / {dietGoals["calorieGoal"]["value"]} {dietGoals["calorieGoal"]["units"]}
+            <Text style={styles.boldText}>{totalMacros["calorieCount"]}</Text> /{" "}
+            {dietGoals["calorieGoal"]["value"]}{" "}
+            {dietGoals["calorieGoal"]["units"]}
           </Text>
         </>
       )}


### PR DESCRIPTION
Changed macro circles to reflect a user's consumption of that macronutrient using react-native-progress import
Updated colour of progress bars on diet and main page to match new colour scheme. (Which is grey-blue and light blue)

### updated overflow colours:
first circle is when it is between 200-300% intake, second is between 100-200% intake and the third is between 0-100% intake:
![3-circle1](https://github.com/user-attachments/assets/7b478b7f-8321-4133-aa9a-c275efcb72af)
first circle shows what it looks like when it is over 300% intake 
![fINAL diet ](https://github.com/user-attachments/assets/99484859-0436-49c9-851a-fcb84a250d60)

### main page progress bar colour change:
![IMG_8226](https://github.com/user-attachments/assets/5d3ec642-3dd9-478d-a1ba-1d1929144aa8)

### How it looks like at 0%: 
![IMG_8227](https://github.com/user-attachments/assets/d6bbbfdd-2202-4751-bd2f-039a7a068c7d)