### PR TITLE
Date in meal page header matching date in diet page where it was clicked from

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -61,7 +61,7 @@ export default function Diet({
   const EmptyMeal = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} 
       onPress={() => { navigationService.navigate("mealPage", {
-        date: day, 
+        dateString: day.toLocaleDateString(), 
         mealName: item.name, 
         meal: meals[item.name],
         deleteFoodEntry: deleteFoodEntry}) }}>
@@ -80,7 +80,7 @@ export default function Diet({
   const MealWithEntries = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} 
       onPress={() => { navigationService.navigate("mealPage", { 
-        date: day, 
+        dateString: day.toLocaleDateString(), 
         mealName: item.name, 
         meal: meals[item.name],
         deleteFoodEntry: deleteFoodEntry}) }}>      

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -60,7 +60,8 @@ export default function Diet({
 
   const EmptyMeal = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} 
-      onPress={() => { navigationService.navigate("mealPage", { 
+      onPress={() => { navigationService.navigate("mealPage", {
+        date: day, 
         mealName: item.name, 
         meal: meals[item.name],
         deleteFoodEntry: deleteFoodEntry}) }}>
@@ -79,6 +80,7 @@ export default function Diet({
   const MealWithEntries = ({ item }) => (
     <TouchableOpacity style={styles.borderedContainer} 
       onPress={() => { navigationService.navigate("mealPage", { 
+        date: day, 
         mealName: item.name, 
         meal: meals[item.name],
         deleteFoodEntry: deleteFoodEntry}) }}>      

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -1,4 +1,3 @@
-//TOFO: figure out which imports are needed and which are redundant
 import React, { useState, useEffect } from "react";
 import {
   View,
@@ -13,9 +12,9 @@ import { Image } from "react-native";
 import navigationService from "../../../navigators/navigationService";
 
 const MealPage = ({navigation, route}) => {
-    const {dateString, mealName, meal, deleteFoodEntry} = route.params; //get a string 
+    const {dateString, mealName, meal, deleteFoodEntry} = route.params;  
     const [currentMeal, setCurrentMeal] = useState(meal);  
-    const [currentDate, setCurrentDate] = useState(new Date()); //holds date object --> allows component display code to just call toLocaleDateString on it easily
+    const [currentDate, setCurrentDate] = useState(new Date()); 
 
     var mealImage;
     if (mealName === "Breakfast"){

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -13,10 +13,10 @@ import { Image } from "react-native";
 import navigationService from "../../../navigators/navigationService";
 
 const MealPage = ({navigation, route}) => {
-    const {date, mealName, meal, deleteFoodEntry} = route.params;
+    const {dateString, mealName, meal, deleteFoodEntry} = route.params; //get a string 
     const [currentMeal, setCurrentMeal] = useState(meal);  
-    const [currentDate, setCurrentDate] = useState(date);
-    
+    const [currentDate, setCurrentDate] = useState(new Date()); //holds date object --> allows component display code to just call toLocaleDateString on it easily
+
     var mealImage;
     if (mealName === "Breakfast"){
       mealImage = require("../../../assets/images/breakfast.png");
@@ -28,42 +28,49 @@ const MealPage = ({navigation, route}) => {
       mealImage = require("../../../assets/images/snack.png");
     }
 
-    const dateString = currentDate.toLocaleDateString(undefined, { year: "numeric",  month: "long", day: "numeric"});
-
     useEffect(() => {
       setCurrentMeal(meal);
-      setCurrentDate(date);
-    }, [meal, date]);
+      extractDate();
+    }, [meal, dateString]);
 
-  const addMealItem = () => {
-    const newFood = {
-      id: mealItemCount,
-      name: "Eggs and bacon",
-      calorieCount: 100,
+    const extractDate = () => {
+      //format of the prop dateString is given as YYYY-MM-DD
+      //Date can take in a year, month and day as constructor arguments - but month index ranges from 0 (Jan) to 11 (Dec)
+      var year = dateString.substring(0, 4);
+      var month = dateString.substring(5, 7);
+      var day = dateString.substring(8);
+      setCurrentDate(new Date(parseInt(year), parseInt(month)-1, parseInt(day)));
+    }
+
+    const addMealItem = () => {
+      const newFood = {
+        id: mealItemCount,
+        name: "Eggs and bacon",
+        calorieCount: 100,
+      };
+      mealSetter([...meal.entries, newFood]);
     };
-    mealSetter([...meal.entries, newFood]);
-  };
 
-  const deleteMealItem = async (id) => {
-    Alert.alert(
-      "Delete Meal Item",
-      "Are you sure you want to delete this meal item?",
-      [
-        { text: "No", style: "cancel" },
-        {
-          text: "Yes",
-          isPreferred: true,
-          onPress: async () => {
-            const updatedMeal = await deleteFoodEntry(id);
-            setCurrentMeal(updatedMeal);
+    const deleteMealItem = async (id) => {
+      Alert.alert(
+        "Delete Meal Item",
+        "Are you sure you want to delete this meal item?",
+        [
+          { text: "No", style: "cancel" },
+          {
+            text: "Yes",
+            isPreferred: true,
+            onPress: async () => {
+              const updatedMeal = await deleteFoodEntry(id);
+              setCurrentMeal(updatedMeal);
+            },
           },
-        },
-      ],
-      {
-        cancelable: true,
-      }
-    );
-  };
+        ],
+        {
+          cancelable: true,
+        }
+      );
+    };
 
     return (
         <SafeAreaView style={styles.container}>
@@ -78,7 +85,9 @@ const MealPage = ({navigation, route}) => {
                         <Image style={styles.mealIcon} source={mealImage}></Image>
                         <Text style={styles.title}>{mealName}</Text>
                     </View>
-                    <Text style={styles.textStyle}>{dateString}</Text>
+                    <Text style={styles.textStyle}>
+                      {currentDate.toLocaleDateString(undefined, {year: "numeric",  month: "long", day: "numeric"})}
+                    </Text>
                 </View>
             </View>
             <View style={styles.mainArea}> 

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -13,8 +13,9 @@ import { Image } from "react-native";
 import navigationService from "../../../navigators/navigationService";
 
 const MealPage = ({navigation, route}) => {
-    const {mealName, meal, deleteFoodEntry} = route.params;
-    const [currentMeal, setCurrentMeal] = useState(meal);    
+    const {date, mealName, meal, deleteFoodEntry} = route.params;
+    const [currentMeal, setCurrentMeal] = useState(meal);  
+    const [currentDate, setCurrentDate] = useState(date);
     
     var mealImage;
     if (mealName === "Breakfast"){
@@ -27,9 +28,12 @@ const MealPage = ({navigation, route}) => {
       mealImage = require("../../../assets/images/snack.png");
     }
 
+    const dateString = currentDate.toLocaleDateString(undefined, { year: "numeric",  month: "long", day: "numeric"});
+
     useEffect(() => {
       setCurrentMeal(meal);
-    }, [meal]);
+      setCurrentDate(date);
+    }, [meal, date]);
 
   const addMealItem = () => {
     const newFood = {
@@ -74,7 +78,7 @@ const MealPage = ({navigation, route}) => {
                         <Image style={styles.mealIcon} source={mealImage}></Image>
                         <Text style={styles.title}>{mealName}</Text>
                     </View>
-                    <Text style={styles.textStyle}>January 1, 2025</Text>
+                    <Text style={styles.textStyle}>{dateString}</Text>
                 </View>
             </View>
             <View style={styles.mainArea}> 


### PR DESCRIPTION
Connected the meal page's date in its header to match the date in the diet page where it's navigated from. 

In order to allow for other pages that will be navigated to from the meal page to maintain the same date, the date of the page is stored as a Date object. However, to avoid a non-serialized prop warning, the date is sent into the meal page as a string, not a Date object. Thus, extraction of the date from the string and into the Date object's constructor is necessary store it accurately.

Conversions of Date objects into strings have been done using the `toLocaleDateString()` function, based on its documentation as found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#syntax ). 
- With no locale or options specified, the string takes on the format of "YYYY-MM-DD".
- Options cannot be specified without a specified locale; with an undefined locale, the host's locale is defaulted to. 
- The options allow for the specification of the display format; this way we can get the full month name in the date's string by specifying a type of `long`, and by omitting a specification for weekday we can omit it from the resultant string. 

Screen recording of behaviour:

https://github.com/user-attachments/assets/af01a543-6a3f-42ef-a5f8-90b64f5b4ee7