### PR TITLE
Basic macro goal editing modal

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -10,7 +10,7 @@ import React from "react";
 import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
-import * as Progress from 'react-native-progress';
+import * as Progress from "react-native-progress";
 
 const mealTitles = [
   {
@@ -47,7 +47,6 @@ const macroKeys = [
 
 const today = new Date();
 
-
 export default function Diet({
   day,
   updateDate,
@@ -55,18 +54,26 @@ export default function Diet({
   dietGoals,
   totalMacros,
   deleteFoodEntry,
-  setMacroModalVisible
+  setMacroModalVisible,
 }) {
-  const consumedPercent = `${(totalMacros.calorieCount / dietGoals.calorieGoal.value * 100).toFixed(0)}%`;
+  const consumedPercent = `${(
+    (totalMacros.calorieCount / dietGoals.calorieGoal.value) *
+    100
+  ).toFixed(0)}%`;
 
   const EmptyMeal = ({ item }) => (
-    <TouchableOpacity style={styles.borderedContainer} 
-      onPress={() => { navigationService.navigate("mealPage", {
-        dateString: day.toLocaleDateString(), 
-        mealName: item.name, 
-        meal: meals[item.name],
-        deleteFoodEntry: deleteFoodEntry}) }}>
-      <View style={[styles.row, {marginBottom: 0}]}>
+    <TouchableOpacity
+      style={styles.borderedContainer}
+      onPress={() => {
+        navigationService.navigate("mealPage", {
+          dateString: day.toLocaleDateString(),
+          mealName: item.name,
+          meal: meals[item.name],
+          deleteFoodEntry: deleteFoodEntry,
+        });
+      }}
+    >
+      <View style={[styles.row, { marginBottom: 0 }]}>
         <Text style={styles.itemText}>{item?.name}</Text>
         <TouchableOpacity>
           <Image
@@ -79,12 +86,17 @@ export default function Diet({
   );
 
   const MealWithEntries = ({ item }) => (
-    <TouchableOpacity style={styles.borderedContainer} 
-      onPress={() => { navigationService.navigate("mealPage", { 
-        dateString: day.toLocaleDateString(), 
-        mealName: item.name, 
-        meal: meals[item.name],
-        deleteFoodEntry: deleteFoodEntry}) }}>      
+    <TouchableOpacity
+      style={styles.borderedContainer}
+      onPress={() => {
+        navigationService.navigate("mealPage", {
+          dateString: day.toLocaleDateString(),
+          mealName: item.name,
+          meal: meals[item.name],
+          deleteFoodEntry: deleteFoodEntry,
+        });
+      }}
+    >
       <View style={styles.row}>
         <Text style={styles.itemText}>{item.name}</Text>
         <TouchableOpacity>
@@ -95,35 +107,38 @@ export default function Diet({
         </TouchableOpacity>
       </View>
       {meals[item.name].entries.map((item, index) => (
-        <View style={[styles.row, {marginBottom: 4}]} key={index}>
-          <Text style={styles.subItemText} >{item.name}</Text>
-          <Text style={styles.subItemText}>{item.calorieCount} {dietGoals.calorieGoal.units}</Text>
+        <View style={[styles.row, { marginBottom: 4 }]} key={index}>
+          <Text style={styles.subItemText}>{item.name}</Text>
+          <Text style={styles.subItemText}>
+            {item.calorieCount} {dietGoals.calorieGoal.units}
+          </Text>
         </View>
       ))}
       <View style={styles.line} />
-      <Text style={[styles.subItemText, { textAlign: "center", }]}>{meals[item.name].calorieCount} {dietGoals.calorieGoal.units}</Text>
+      <Text style={[styles.subItemText, { textAlign: "center" }]}>
+        {meals[item.name].calorieCount} {dietGoals.calorieGoal.units}
+      </Text>
     </TouchableOpacity>
   );
 
-  const MacroProgressCircle = ({item}) => (
-    <View >
-      <Progress.Circle 
-        progress={totalMacros[item.consumed]/dietGoals[item.goal]} 
-        strokeCap="round" 
-        size={93} 
+  const MacroProgressCircle = ({ item }) => (
+    <View>
+      <Progress.Circle
+        progress={totalMacros[item.consumed] / dietGoals[item.goal]}
+        strokeCap="round"
+        size={93}
         thickness={9}
         unfilledColor="#ACC5CC"
         color="#D7F6FF"
         borderWidth={1}
         borderColor="#ACC5CC"
       />
-      <View style = {styles.progressCirlceContent}>
-        <Text style={[ styles.boldText, {fontSize: 22,}]}>
+      <View style={styles.progressCirlceContent}>
+        <Text style={[styles.boldText, { fontSize: 22 }]}>
           {totalMacros[item.consumed]}g
         </Text>
         <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
       </View>
-      
     </View>
   );
 
@@ -149,7 +164,6 @@ export default function Diet({
         </View>
       </View>
 
-
       <View style={sharedStyles.datePickerView}>
         <TouchableOpacity
           style={sharedStyles.changeDateButton}
@@ -162,7 +176,7 @@ export default function Diet({
         </TouchableOpacity>
         <>
           {moment(day).format("YYYYMMDD") ==
-            moment(today).format("YYYYMMDD") ? (
+          moment(today).format("YYYYMMDD") ? (
             <Text style={sharedStyles.dateText}>Today</Text>
           ) : (
             <Text style={sharedStyles.dateText}>
@@ -184,7 +198,11 @@ export default function Diet({
       <View style={styles.borderedContainer}>
         <View style={styles.row}>
           <Text style={[styles.boldText, { marginBottom: 10 }]}>Macros</Text>
-          <TouchableOpacity onPress={()=>{setMacroModalVisible(true)}}>
+          <TouchableOpacity
+            onPress={() => {
+              setMacroModalVisible(true);
+            }}
+          >
             <Image
               style={styles.plus}
               source={require("../../assets/images/edit.png")}
@@ -199,11 +217,13 @@ export default function Diet({
           <Text style={styles.desc}>
             <Text style={styles.boldText}>{totalMacros.calorieCount}</Text> kcal
           </Text>
-          <Text style={styles.boldText}>{dietGoals.calorieGoal.value - totalMacros.calorieCount}</Text>
+          <Text style={styles.boldText}>
+            {dietGoals.calorieGoal.value - totalMacros.calorieCount}
+          </Text>
         </View>
 
         <View style={styles.progress}>
-          <View style={[styles.filler, {width: consumedPercent,},]}/>
+          <View style={[styles.filler, { width: consumedPercent }]} />
         </View>
         <View style={[styles.row, { gap: 10 }]}>
           {macroKeys.map((item, index) => (
@@ -213,16 +233,15 @@ export default function Diet({
             </View>
           ))}
         </View>
-      </View> 
-      
+      </View>
 
-      {mealTitles.map((item, index) => (
+      {mealTitles.map((item, index) =>
         meals[item.name].entries.length > 0 ? (
           <MealWithEntries item={item} key={index} />
         ) : (
           <EmptyMeal item={item} key={index} />
         )
-      ))}
+      )}
     </ScrollView>
   );
 }
@@ -374,16 +393,16 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   progressCirlceContent: {
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
   },
   line: {
-    borderBottomColor: '#ccc',
+    borderBottomColor: "#ccc",
     borderBottomWidth: 1,
     marginVertical: 10,
   },

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -54,7 +54,8 @@ export default function Diet({
   meals,
   dietGoals,
   totalMacros,
-  deleteFoodEntry
+  deleteFoodEntry,
+  setMacroModalVisible
 }) {
   const consumedPercent = `${(totalMacros.calorieCount / dietGoals.calorieGoal.value * 100).toFixed(0)}%`;
 
@@ -181,7 +182,7 @@ export default function Diet({
       <View style={styles.borderedContainer}>
         <View style={styles.row}>
           <Text style={[styles.boldText, { marginBottom: 10 }]}>Macros</Text>
-          <TouchableOpacity>
+          <TouchableOpacity onPress={()=>{setMacroModalVisible(true)}}>
             <Image
               style={styles.plus}
               source={require("../../assets/images/edit.png")}

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -21,6 +21,7 @@ import DietGoalsAPI from "../../api/diet/dietGoalsAPI";
 import UserAPI from "../../api/user/userAPI";
 import { sharedStyles } from "../styles";
 import AddEntryModal from "./modals/AddEntryModal";
+import EditMacroGoalsModal from "./modals/EditMacroGoalsModal";
 
 const FitnessDiet = ({ navigation }) => {
   const [index, setIndex] = useState(0);
@@ -60,6 +61,7 @@ const FitnessDiet = ({ navigation }) => {
   const [dietGoals, setDietGoals] = useState({"calorieGoal": {"units": "kcal", "value": 2000}, "carbGoal": 200, "fatGoal": 67 , "proteinGoal": 150});
 
   const [dietModalVisible, setDietVisible] = useState(false);
+  const [editMacroModalVisible, setEditVisible] = useState(false);
 
   const updateDate = (dateChange) => {
     var dayValue = 60 * 60 * 24 * 1000 * dateChange;
@@ -284,6 +286,7 @@ const FitnessDiet = ({ navigation }) => {
             totalMacros={totalMacros}
             dietGoals={dietGoals}
             deleteFoodEntry={deleteFoodEntry}
+            setMacroModalVisible={setEditVisible}
           />
         );
       case "third":
@@ -333,6 +336,10 @@ const FitnessDiet = ({ navigation }) => {
         isVisible={dietModalVisible} 
         setVisible={setDietVisible} 
         dayString={day.toLocaleDateString(undefined, { year: "numeric",  month: "long", day: "numeric"})}
+      />
+      <EditMacroGoalsModal 
+        isVisible={editMacroModalVisible} 
+        setVisible={setEditVisible} 
         />
       
     </SafeAreaView>

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -181,15 +181,17 @@ const onUpdateMacroValue = async (title, value, units) => {
           ))}
         </View>
         <View>
-            <TouchableOpacity style={styles.button}>
-                <Text style={styles.buttonText}>Recalculate Goals</Text>
+            <TouchableOpacity style={[styles.button, styles.recalculateButton]}>
+                <Text style={styles.buttonText}>Recalculate goals</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.button}>
-                <Text style={styles.buttonText}>Close</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.button}>
-                <Text style={styles.buttonText}>Save</Text>
-            </TouchableOpacity>
+            <View style={styles.buttonContainer}>
+                <TouchableOpacity style={[styles.button, styles.closeButton]}>
+                    <Text style={styles.buttonText}>Close</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={[styles.button, styles.saveButton]}>
+                    <Text style={styles.buttonText}>Save</Text>
+                </TouchableOpacity>
+            </View>            
         </View>
       <UpdateMacrosModal
         getRef={(ref) => (updateMacrosRef.current = ref)}
@@ -297,6 +299,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
+  buttonContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+  },
   button: {
     borderRadius: 25,
     borderWidth: 1,
@@ -305,11 +312,27 @@ const styles = StyleSheet.create({
     padding: 10,
     alignSelf: "center",
     alignContent: "center",
-    marginBottom: 10,
+    marginVertical: 5,
+  },
+  recalculateButton: {
+    width: "70%",
+    backgroundColor: "#CABDFF",
+    borderColor: "rgba(172, 197, 204, 0.75)"
+  },
+  closeButton: {
+    width: "35%",
+    marginHorizontal: 2,
+    borderColor: "rgba(172, 197, 204, 0.75)",
+  },
+  saveButton: {
+    width: "35%",
+    marginHorizontal: 2,
+    backgroundColor: "#D7F6FF", 
+    borderColor: "rgba(172, 197, 204, 0.75)",
   },
   buttonText: {
-    fontSize: 16,
-    fontFamily: "Sego",
+    fontSize: 18,
+    fontFamily: "Sego-Bold",
     color: "#25436B",
   },
 });

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -1,16 +1,120 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
+import { Header } from "../../../components";
+import DietGoalsAPI from "../../../api/diet/dietGoalsAPI";
+import { getAccessToken } from "../../../user/keychain";
+import Spinner from "react-native-loading-spinner-overlay";
+import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
 
 export default function EditMacroGoalsModal({ isVisible, setVisible }) {
-  const [selectedIndex, setSelected] = useState(-1);
+  const [datas, setDatas] = useState([
+      {
+        title: "0 g",
+        img: require("../../../assets/images/carbs.png"),
+        text: "Carbs:",
+      },
+      {
+        title: "0 g",
+        img: require("../../../assets/images/protein.png"),
+        text: "Protein:",
+      },
+      {
+        title: "0 g",
+        img: require("../../../assets/images/fats.png"),
+        text: "Fats:",
+      },
+    ]);
+    const [calorieGoalValue, setCalorieGoalValue] = useState(0);
+    const [calories, setCalories] = useState(0);
+    const [calorieUnit, setCalorieUnit] = useState("kcal");
+    const [carbGoalValue, setCarbGoalValue] = useState(0);
+    const [proteinGoalValue, setProteinGoalValue] = useState(0);
+    const [fatGoalValue, setFatGoalValue] = useState(0);
+    const [isLoading, setIsLoading] = useState(false);
+  
+    const updateMacrosRef = useRef(null);
 
-  const updateSelected = (currIndex) => {
-    if (selectedIndex == currIndex) setSelected(-1);
-    else setSelected(currIndex);
+const onUpdateMacroValue = async (title, value, units) => {
+    var newCalories = calorieGoalValue;
+    var newFats = fatGoalValue;
+    var newProteins = proteinGoalValue;
+    var newCarbs = carbGoalValue;
+    if (title === "Calories") {
+      setCalories(value);
+      setCalorieUnit(units);
+      newCalories = { value: value, units: units };
+      setCalorieGoalValue(newCalories);
+    } else {
+      let newDatas = datas.map((item) => {
+        if (item.text === title) {
+          if (title === "Carbs:") {
+            newCarbs = value;
+            setCarbGoalValue(value);
+          }
+          if (title === "Protein:") {
+            newProteins = value;
+            setProteinGoalValue(value);
+          }
+          if (title === "Fats:") {
+            newFats = value;
+            setFatGoalValue(value);
+          }
+          return {
+            ...item,
+            title: value + " " + units,
+          };
+        }
+        return item;
+      });
+      setDatas(newDatas);
+      const token = await getAccessToken();
+      DietGoalsAPI.updateDietGoals(token, {
+        carbGoal: newCarbs,
+        proteinGoal: newProteins,
+        fatGoal: newFats,
+        calorieGoal: newCalories,
+      });
+    }
   };
+
+  useEffect(() => {
+    const getDataOnLoad = async () => {
+      setIsLoading(true);
+      const token = await getAccessToken();
+      const dietGoals = await DietGoalsAPI.getDietGoals(token);
+
+      setCalorieGoalValue(dietGoals.calorieGoal);
+      setCalorieUnit(dietGoals.calorieGoal.units);
+      setCalories(dietGoals.calorieGoal.value);
+      setCarbGoalValue(dietGoals.carbGoal);
+      setProteinGoalValue(dietGoals.proteinGoal);
+      setFatGoalValue(dietGoals.fatGoal);
+
+      setDatas([
+        {
+          title: `${Math.round(dietGoals.carbGoal)} g`,
+          img: require("../../../assets/images/carbs.png"),
+          text: "Carbs:",
+        },
+        {
+          title: `${Math.round(dietGoals.proteinGoal)} g`,
+          img: require("../../../assets/images/protein.png"),
+          text: "Protein:",
+        },
+        {
+          title: `${Math.round(dietGoals.fatGoal)} g`,
+          img: require("../../../assets/images/fats.png"),
+          text: "Fats:",
+        },
+      ]);
+      setIsLoading(false);
+    };
+
+    getDataOnLoad();
+  }, []);
 
   return (
     <RNModal
@@ -21,7 +125,70 @@ export default function EditMacroGoalsModal({ isVisible, setVisible }) {
       style={styles.modal}
     >
     <View style={styles.container}>
-        <Text>test</Text>
+      <Header showCenter={false} />
+      <Spinner visible={isLoading}></Spinner>
+      <View style={styles.contentContainerStyle}>
+        <Text style={styles.title}>Goals</Text>
+        <View style={styles.macroContainerStyle}>
+          <View style={[styles.item, styles.head]}>
+            <View style={[styles.item, styles.headItem]}>
+              <View style={styles.row}>
+                <Image
+                  source={require("../../../assets/images/calories.png")}
+                  style={styles.calorieItemImg}
+                />
+                <Text style={styles.calorieText}>Calories</Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => {
+                  updateMacrosRef.current.open({
+                    title: "Calories",
+                    isCal: true,
+                    units: calorieUnit,
+                    value: calories,
+                  });
+                }}
+              >
+                <Image
+                  style={styles.calorieEditImg}
+                  source={require("../../../assets/images/edit.png")}
+                />
+              </TouchableOpacity>
+            </View>
+            <Text style={styles.calorieTitle}>
+              {calories} {calorieUnit}
+            </Text>
+          </View>
+          {datas.map((item, index) => (
+            <View style={styles.item} key={index}>
+              <View style={styles.row}>
+                <Image source={item.img} style={styles.itemImg} />
+                <Text style={styles.text}>{item.text}</Text>
+                <Text style={styles.itemTitle}>{item.title}</Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => {
+                  updateMacrosRef.current.open({
+                    title: item.text,
+                    isCal: false,
+                    units: "g",
+                    value: item.title,
+                  });
+                }}
+              >
+                <Image
+                  style={styles.editImg}
+                  source={require("../../../assets/images/edit.png")}
+                />
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      </View>
+      <UpdateMacrosModal
+        getRef={(ref) => (updateMacrosRef.current = ref)}
+        onUpdateMacroValue={onUpdateMacroValue}
+      />
     </View>
       
     </RNModal>
@@ -29,60 +196,97 @@ export default function EditMacroGoalsModal({ isVisible, setVisible }) {
 }
 
 const styles = StyleSheet.create({
-  modal: {
-    margin: 0,
-    alignItems: "center",
-    justifyContent: "center",
-  },
   container: {
-    width: "90%",
-    paddingVertical: 15,
-    backgroundColor: "white",
-    borderRadius: 30,
-    borderWidth: 1,
-    borderBlockColor: "rgba(0,0,0,0.5)",
+    flex: 1,
+    backgroundColor: "#fff",
   },
-  line: {
-    borderBottomColor: "#ccc",
-    borderBottomWidth: 2,
+  contentContainerStyle: {
+    paddingTop: 20,
   },
-  titleText: {
-    fontFamily: "Sego",
-    fontSize: 33,
+  macroContainerStyle: {
+    paddingTop: 50,
+  },
+  title: {
+    fontFamily: "Sego-Bold",
+    fontSize: 36,
     color: "#25436B",
-    marginVertical: 20,
+    marginVertical: 25,
     alignSelf: "center",
   },
-  rowText: {
-    fontSize: 24,
+  head: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+    paddingHorizontal: 20,
+  },
+  headItem: {
+    borderWidth: 0,
+    padding: 0,
+    width: "100%",
+    marginHorizontal: 0,
+    paddingVertical: 0,
+  },
+  item: {
+    borderWidth: 1,
+    borderColor: "#CCCCCC",
+    borderRadius: 30,
+    marginHorizontal: 20,
+    marginBottom: 15,
+    padding: 10,
+    paddingVertical: 15,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  itemTitle: {
+    fontSize: 16,
     fontFamily: "Sego-Bold",
     color: "#25436B",
+    marginLeft: 15,
+  },
+  calorieTitle: {
+    fontFamily: "Sego-Bold",
+    color: "#25436B",
+    fontSize: 22,
+  },
+  calorieText: {
+    fontSize: 20,
+    fontFamily: "Sego",
+    color: "#25436B",
+  },
+  calorieEditImg: {
+    width: 30,
+    height: 30,
+  },
+  calorieItemImg: {
+    width: 30,
+    height: 30,
+    marginRight: 5,
+  },
+  itemImg: {
+    width: 24,
+    height: 24,
+    marginRight: 5,
   },
   row: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 7,
   },
-  icon: {
-    height: 30,
-    width: 30,
-    marginRight: 10,
-    marginLeft: 50,
+  editImg: {
+    width: 24,
+    height: 24,
   },
-  button: {
-    borderRadius: 25,
-    borderWidth: 2,
-    alignItems: "center",
-    width: "60%",
-    padding: 5,
-    alignSelf: "center",
-    alignContent: "center",
-    marginTop: 30,
-    marginBottom: 15,
-  },
-  buttonText: {
-    fontSize: 24,
+  text: {
+    fontSize: 16,
     fontFamily: "Sego",
     color: "#25436B",
+  },
+  flex: {
+    flex: 1,
+    justifyContent: "center",
+  },
+
+  minitext: {
+    fontSize: 16,
+    marginTop: 10,
   },
 });

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -125,10 +125,7 @@ const onUpdateMacroValue = async (title, value, units) => {
       style={styles.modal}
     >
     <View style={styles.container}>
-      <Header showCenter={false} />
       <Spinner visible={isLoading}></Spinner>
-      <View style={styles.contentContainerStyle}>
-        <Text style={styles.title}>Goals</Text>
         <View style={styles.macroContainerStyle}>
           <View style={[styles.item, styles.head]}>
             <View style={[styles.item, styles.headItem]}>
@@ -174,8 +171,7 @@ const onUpdateMacroValue = async (title, value, units) => {
                     units: "g",
                     value: item.title,
                   });
-                }}
-              >
+                }} >
                 <Image
                   style={styles.editImg}
                   source={require("../../../assets/images/edit.png")}
@@ -184,7 +180,17 @@ const onUpdateMacroValue = async (title, value, units) => {
             </View>
           ))}
         </View>
-      </View>
+        <View>
+            <TouchableOpacity style={styles.button}>
+                <Text style={styles.buttonText}>Recalculate Goals</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.button}>
+                <Text style={styles.buttonText}>Close</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.button}>
+                <Text style={styles.buttonText}>Save</Text>
+            </TouchableOpacity>
+        </View>
       <UpdateMacrosModal
         getRef={(ref) => (updateMacrosRef.current = ref)}
         onUpdateMacroValue={onUpdateMacroValue}
@@ -196,15 +202,21 @@ const onUpdateMacroValue = async (title, value, units) => {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
+    modal: {
+    margin: 0,
+    alignItems: "center",
+    justifyContent: "center",
   },
-  contentContainerStyle: {
-    paddingTop: 20,
+  container: {
+    width: "90%",
+    paddingVertical: 15,
+    backgroundColor: "white",
+    borderRadius: 30,
+    borderWidth: 2,
+    borderColor: "#CCCCCC",
   },
   macroContainerStyle: {
-    paddingTop: 50,
+    paddingTop: 20,
   },
   title: {
     fontFamily: "Sego-Bold",
@@ -232,7 +244,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 20,
     marginBottom: 15,
     padding: 10,
-    paddingVertical: 15,
+    paddingVertical: 5,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
@@ -270,6 +282,7 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
+    marginTop: 5,
   },
   editImg: {
     width: 24,
@@ -284,9 +297,19 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
-
-  minitext: {
+  button: {
+    borderRadius: 25,
+    borderWidth: 1,
+    borderColor: "#CCCCCC",
+    alignItems: "center",
+    padding: 10,
+    alignSelf: "center",
+    alignContent: "center",
+    marginBottom: 10,
+  },
+  buttonText: {
     fontSize: 16,
-    marginTop: 10,
+    fontFamily: "Sego",
+    color: "#25436B",
   },
 });

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import RNModal from "react-native-modal";
+import navigationService from "../../../navigators/navigationService";
+
+const mealTitles = [
+  {
+    name: "Breakfast",
+    icon: require("../../../assets/images/breakfast.png"),
+  },
+  {
+    name: "Lunch",
+    icon: require("../../../assets/images/lunch.png"),
+  },
+  {
+    name: "Dinner",
+    icon: require("../../../assets/images/dinner.png"),
+  },
+  {
+    name: "Snacks",
+    icon: require("../../../assets/images/snack.png"),
+  },
+];
+
+export default function AddEntryModal({ isVisible, setVisible, dayString }) {
+  const [selectedIndex, setSelected] = useState(-1);
+
+  const updateSelected = (currIndex) => {
+    if (selectedIndex == currIndex) setSelected(-1);
+    else setSelected(currIndex);
+  };
+
+  return (
+    <RNModal
+      isVisible={isVisible}
+      onBackButtonPress={() => setVisible(false)}
+      onBackdropPress={() => setVisible(false)}
+      backdropOpacity={0}
+      style={styles.modal}
+    >
+      <View style={styles.container}>
+        <Text style={styles.titleText}>Select Meal </Text>
+        {mealTitles.map((item, index) => (
+          <View key={index}>
+            <View style={styles.line} />
+            <TouchableOpacity
+              style={[
+                selectedIndex == index && {
+                  backgroundColor: "rgba(179,179,179,0.2)",
+                },
+              ]}
+              onPress={() => updateSelected(index)}
+            >
+              <View style={styles.row}>
+                <Image style={styles.icon} source={item.icon}></Image>
+                <Text style={styles.rowText}>{item.name}</Text>
+              </View>
+            </TouchableOpacity>
+          </View>
+        ))}
+        <View style={styles.line} />
+
+        <TouchableOpacity
+          style={[
+            styles.button,
+            selectedIndex == -1
+              ? { backgroundColor: "#D3D3D3", borderColor: "#B3B3B3" }
+              : { backgroundColor: "#D7F6FF", borderColor: "rgba(172, 197, 204, 0.75)"},
+          ]}
+          disabled={selectedIndex == -1}
+          onPress={() => {
+            navigationService.navigate("searchFood", {
+              mealName: mealTitles[selectedIndex].name,
+              dayString: dayString,
+            });
+            setVisible(false);
+            setSelected(-1);
+          }}
+        >
+          <Text
+            style={[
+              styles.buttonText,
+              selectedIndex == -1 && { color: "#666666" },
+            ]}
+          >
+            Continue
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </RNModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    margin: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  container: {
+    width: "90%",
+    paddingVertical: 15,
+    backgroundColor: "white",
+    borderRadius: 30,
+    borderWidth: 1,
+    borderBlockColor: "rgba(0,0,0,0.5)",
+  },
+  line: {
+    borderBottomColor: "#ccc",
+    borderBottomWidth: 2,
+  },
+  titleText: {
+    fontFamily: "Sego",
+    fontSize: 33,
+    color: "#25436B",
+    marginVertical: 20,
+    alignSelf: "center",
+  },
+  rowText: {
+    fontSize: 24,
+    fontFamily: "Sego-Bold",
+    color: "#25436B",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 7,
+  },
+  icon: {
+    height: 30,
+    width: 30,
+    marginRight: 10,
+    marginLeft: 50,
+  },
+  button: {
+    borderRadius: 25,
+    borderWidth: 2,
+    alignItems: "center",
+    width: "60%",
+    padding: 5,
+    alignSelf: "center",
+    alignContent: "center",
+    marginTop: 30,
+    marginBottom: 15,
+  },
+  buttonText: {
+    fontSize: 24,
+    fontFamily: "Sego",
+    color: "#25436B",
+  },
+});

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -116,6 +116,10 @@ const onUpdateMacroValue = async (title, value, units) => {
     getDataOnLoad();
   }, []);
 
+  const closeModal = async () => {
+    setVisible(false);
+  };
+
   return (
     <RNModal
       isVisible={isVisible}
@@ -181,14 +185,14 @@ const onUpdateMacroValue = async (title, value, units) => {
           ))}
         </View>
         <View>
-            <TouchableOpacity style={[styles.button, styles.recalculateButton]}>
+            <TouchableOpacity style={[styles.button, styles.recalculateButton]} onPress={() => closeModal()}>
                 <Text style={styles.buttonText}>Recalculate goals</Text>
             </TouchableOpacity>
             <View style={styles.buttonContainer}>
-                <TouchableOpacity style={[styles.button, styles.closeButton]}>
+                <TouchableOpacity style={[styles.button, styles.closeButton]} onPress={() => closeModal()}>
                     <Text style={styles.buttonText}>Close</Text>
                 </TouchableOpacity>
-                <TouchableOpacity style={[styles.button, styles.saveButton]}>
+                <TouchableOpacity style={[styles.button, styles.saveButton]} onPress={() => closeModal()}>
                     <Text style={styles.buttonText}>Save</Text>
                 </TouchableOpacity>
             </View>            

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -8,36 +8,35 @@ import { getAccessToken } from "../../../user/keychain";
 import Spinner from "react-native-loading-spinner-overlay";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
-
 export default function EditMacroGoalsModal({ isVisible, setVisible }) {
   const [datas, setDatas] = useState([
-      {
-        title: "0 g",
-        img: require("../../../assets/images/carbs.png"),
-        text: "Carbs:",
-      },
-      {
-        title: "0 g",
-        img: require("../../../assets/images/protein.png"),
-        text: "Protein:",
-      },
-      {
-        title: "0 g",
-        img: require("../../../assets/images/fats.png"),
-        text: "Fats:",
-      },
-    ]);
-    const [calorieGoalValue, setCalorieGoalValue] = useState(0);
-    const [calories, setCalories] = useState(0);
-    const [calorieUnit, setCalorieUnit] = useState("kcal");
-    const [carbGoalValue, setCarbGoalValue] = useState(0);
-    const [proteinGoalValue, setProteinGoalValue] = useState(0);
-    const [fatGoalValue, setFatGoalValue] = useState(0);
-    const [isLoading, setIsLoading] = useState(false);
-  
-    const updateMacrosRef = useRef(null);
+    {
+      title: "0 g",
+      img: require("../../../assets/images/carbs.png"),
+      text: "Carbs:",
+    },
+    {
+      title: "0 g",
+      img: require("../../../assets/images/protein.png"),
+      text: "Protein:",
+    },
+    {
+      title: "0 g",
+      img: require("../../../assets/images/fats.png"),
+      text: "Fats:",
+    },
+  ]);
+  const [calorieGoalValue, setCalorieGoalValue] = useState(0);
+  const [calories, setCalories] = useState(0);
+  const [calorieUnit, setCalorieUnit] = useState("kcal");
+  const [carbGoalValue, setCarbGoalValue] = useState(0);
+  const [proteinGoalValue, setProteinGoalValue] = useState(0);
+  const [fatGoalValue, setFatGoalValue] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
 
-const onUpdateMacroValue = async (title, value, units) => {
+  const updateMacrosRef = useRef(null);
+
+  const onUpdateMacroValue = async (title, value, units) => {
     var newCalories = calorieGoalValue;
     var newFats = fatGoalValue;
     var newProteins = proteinGoalValue;
@@ -71,45 +70,49 @@ const onUpdateMacroValue = async (title, value, units) => {
       });
       setDatas(newDatas);
       const token = await getAccessToken();
-      DietGoalsAPI.updateDietGoals(token, {
+      await DietGoalsAPI.updateDietGoals(token, {
         carbGoal: newCarbs,
         proteinGoal: newProteins,
         fatGoal: newFats,
         calorieGoal: newCalories,
       });
+      setMacros();
     }
+  };
+
+  const setMacros = async () => {
+    const dietGoals = await DietGoalsAPI.getDietGoals(token);
+
+    setCalorieGoalValue(dietGoals.calorieGoal);
+    setCalorieUnit(dietGoals.calorieGoal.units);
+    setCalories(dietGoals.calorieGoal.value);
+    setCarbGoalValue(dietGoals.carbGoal);
+    setProteinGoalValue(dietGoals.proteinGoal);
+    setFatGoalValue(dietGoals.fatGoal);
+
+    setDatas([
+      {
+        title: `${Math.round(dietGoals.carbGoal)} g`,
+        img: require("../../../assets/images/carbs.png"),
+        text: "Carbs:",
+      },
+      {
+        title: `${Math.round(dietGoals.proteinGoal)} g`,
+        img: require("../../../assets/images/protein.png"),
+        text: "Protein:",
+      },
+      {
+        title: `${Math.round(dietGoals.fatGoal)} g`,
+        img: require("../../../assets/images/fats.png"),
+        text: "Fats:",
+      },
+    ]);
   };
 
   useEffect(() => {
     const getDataOnLoad = async () => {
       setIsLoading(true);
-      const token = await getAccessToken();
-      const dietGoals = await DietGoalsAPI.getDietGoals(token);
-
-      setCalorieGoalValue(dietGoals.calorieGoal);
-      setCalorieUnit(dietGoals.calorieGoal.units);
-      setCalories(dietGoals.calorieGoal.value);
-      setCarbGoalValue(dietGoals.carbGoal);
-      setProteinGoalValue(dietGoals.proteinGoal);
-      setFatGoalValue(dietGoals.fatGoal);
-
-      setDatas([
-        {
-          title: `${Math.round(dietGoals.carbGoal)} g`,
-          img: require("../../../assets/images/carbs.png"),
-          text: "Carbs:",
-        },
-        {
-          title: `${Math.round(dietGoals.proteinGoal)} g`,
-          img: require("../../../assets/images/protein.png"),
-          text: "Protein:",
-        },
-        {
-          title: `${Math.round(dietGoals.fatGoal)} g`,
-          img: require("../../../assets/images/fats.png"),
-          text: "Fats:",
-        },
-      ]);
+      setMacros();
       setIsLoading(false);
     };
 
@@ -128,8 +131,8 @@ const onUpdateMacroValue = async (title, value, units) => {
       backdropOpacity={0}
       style={styles.modal}
     >
-    <View style={styles.container}>
-      <Spinner visible={isLoading}></Spinner>
+      <View style={styles.container}>
+        <Spinner visible={isLoading}></Spinner>
         <View style={styles.macroContainerStyle}>
           <View style={[styles.item, styles.head]}>
             <View style={[styles.item, styles.headItem]}>
@@ -175,7 +178,8 @@ const onUpdateMacroValue = async (title, value, units) => {
                     units: "g",
                     value: item.title,
                   });
-                }} >
+                }}
+              >
                 <Image
                   style={styles.editImg}
                   source={require("../../../assets/images/edit.png")}
@@ -185,30 +189,38 @@ const onUpdateMacroValue = async (title, value, units) => {
           ))}
         </View>
         <View>
-            <TouchableOpacity style={[styles.button, styles.recalculateButton]} onPress={() => closeModal()}>
-                <Text style={styles.buttonText}>Recalculate goals</Text>
+          <TouchableOpacity
+            style={[styles.button, styles.recalculateButton]}
+            onPress={() => closeModal()}
+          >
+            <Text style={styles.buttonText}>Recalculate goals</Text>
+          </TouchableOpacity>
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity
+              style={[styles.button, styles.closeButton]}
+              onPress={() => closeModal()}
+            >
+              <Text style={styles.buttonText}>Close</Text>
             </TouchableOpacity>
-            <View style={styles.buttonContainer}>
-                <TouchableOpacity style={[styles.button, styles.closeButton]} onPress={() => closeModal()}>
-                    <Text style={styles.buttonText}>Close</Text>
-                </TouchableOpacity>
-                <TouchableOpacity style={[styles.button, styles.saveButton]} onPress={() => closeModal()}>
-                    <Text style={styles.buttonText}>Save</Text>
-                </TouchableOpacity>
-            </View>            
+            <TouchableOpacity
+              style={[styles.button, styles.saveButton]}
+              onPress={() => closeModal()}
+            >
+              <Text style={styles.buttonText}>Save</Text>
+            </TouchableOpacity>
+          </View>
         </View>
-      <UpdateMacrosModal
-        getRef={(ref) => (updateMacrosRef.current = ref)}
-        onUpdateMacroValue={onUpdateMacroValue}
-      />
-    </View>
-      
+        <UpdateMacrosModal
+          getRef={(ref) => (updateMacrosRef.current = ref)}
+          onUpdateMacroValue={onUpdateMacroValue}
+        />
+      </View>
     </RNModal>
   );
 }
 
 const styles = StyleSheet.create({
-    modal: {
+  modal: {
     margin: 0,
     alignItems: "center",
     justifyContent: "center",
@@ -321,7 +333,7 @@ const styles = StyleSheet.create({
   recalculateButton: {
     width: "70%",
     backgroundColor: "#CABDFF",
-    borderColor: "rgba(172, 197, 204, 0.75)"
+    borderColor: "rgba(172, 197, 204, 0.75)",
   },
   closeButton: {
     width: "35%",
@@ -331,7 +343,7 @@ const styles = StyleSheet.create({
   saveButton: {
     width: "35%",
     marginHorizontal: 2,
-    backgroundColor: "#D7F6FF", 
+    backgroundColor: "#D7F6FF",
     borderColor: "rgba(172, 197, 204, 0.75)",
   },
   buttonText: {

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -3,26 +3,8 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
 
-const mealTitles = [
-  {
-    name: "Breakfast",
-    icon: require("../../../assets/images/breakfast.png"),
-  },
-  {
-    name: "Lunch",
-    icon: require("../../../assets/images/lunch.png"),
-  },
-  {
-    name: "Dinner",
-    icon: require("../../../assets/images/dinner.png"),
-  },
-  {
-    name: "Snacks",
-    icon: require("../../../assets/images/snack.png"),
-  },
-];
 
-export default function AddEntryModal({ isVisible, setVisible, dayString }) {
+export default function EditMacroGoalsModal({ isVisible, setVisible }) {
   const [selectedIndex, setSelected] = useState(-1);
 
   const updateSelected = (currIndex) => {
@@ -38,55 +20,10 @@ export default function AddEntryModal({ isVisible, setVisible, dayString }) {
       backdropOpacity={0}
       style={styles.modal}
     >
-      <View style={styles.container}>
-        <Text style={styles.titleText}>Select Meal </Text>
-        {mealTitles.map((item, index) => (
-          <View key={index}>
-            <View style={styles.line} />
-            <TouchableOpacity
-              style={[
-                selectedIndex == index && {
-                  backgroundColor: "rgba(179,179,179,0.2)",
-                },
-              ]}
-              onPress={() => updateSelected(index)}
-            >
-              <View style={styles.row}>
-                <Image style={styles.icon} source={item.icon}></Image>
-                <Text style={styles.rowText}>{item.name}</Text>
-              </View>
-            </TouchableOpacity>
-          </View>
-        ))}
-        <View style={styles.line} />
-
-        <TouchableOpacity
-          style={[
-            styles.button,
-            selectedIndex == -1
-              ? { backgroundColor: "#D3D3D3", borderColor: "#B3B3B3" }
-              : { backgroundColor: "#D7F6FF", borderColor: "rgba(172, 197, 204, 0.75)"},
-          ]}
-          disabled={selectedIndex == -1}
-          onPress={() => {
-            navigationService.navigate("searchFood", {
-              mealName: mealTitles[selectedIndex].name,
-              dayString: dayString,
-            });
-            setVisible(false);
-            setSelected(-1);
-          }}
-        >
-          <Text
-            style={[
-              styles.buttonText,
-              selectedIndex == -1 && { color: "#666666" },
-            ]}
-          >
-            Continue
-          </Text>
-        </TouchableOpacity>
-      </View>
+    <View style={styles.container}>
+        <Text>test</Text>
+    </View>
+      
     </RNModal>
   );
 }


### PR DESCRIPTION
Created a basic modal based on the contents and layout of the goals page in settings (`src/screens/settings/Goals.js`). This includes a section for each of the 4 macros tracked in Oasis (calories, carbs, protein, fats) as well as buttons to save basic changes, exit/close the modal, and navigate to the goal calculation questionnaire in the app setup. 

Functionality, including saving changes and navigating to the questionnaire will be covered in later pull requests. At this time, all 3 buttons are made to just close the modal when pressed. 

Since the setup and formatting is borrowed from the goals page, editing is currently enabled via the UpdateMacrosModal popup - but changes using this are not yet saved properly, and are inconsistently saved when changing to other sections of the app and back to the diet area. This will be resolved in a later PR. 
The displaying of current macro goals in the modal is also already accomplished thanks to borrowing from the goals page.

Screenshot of open modal: 
![macro modal basic view](https://github.com/user-attachments/assets/b86b0ff8-b357-429a-91de-aa9de8dac492)

Screen recording of current behaviour of modal:

https://github.com/user-attachments/assets/f0b309ec-5d16-497a-948f-cc97c069805c