### PR TITLE
Macro goal editing - updating and saving goal value changes

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -57,6 +57,7 @@ export default function Diet({
   deleteFoodEntry,
   setMacroModalVisible,
   getGoals,
+  updateGoals,
 }) {
   const editMacroGoalsRef = useRef(null);
   const calorieDif = dietGoals.calorieGoal.value - totalMacros.calorieCount;
@@ -298,7 +299,7 @@ export default function Diet({
       </ScrollView>
       <EditMacroGoalsModal
         getRef={(ref) => (editMacroGoalsRef.current = ref)}
-        getGoals={getGoals}
+        updateGoals={updateGoals}
       />
     </>
   );

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -249,21 +249,6 @@ export default function Diet({
             <TouchableOpacity
               onPress={() => {
                 getGoals();
-                console.log(
-                  "diet goals object: " +
-                    JSON.stringify(dietGoals) +
-                    "\ndiet goals contents in diet.js:" +
-                    "\ncalories goal: " +
-                    dietGoals.calorieGoal.value +
-                    " " +
-                    dietGoals.calorieGoal.units +
-                    "\ncarb goal: " +
-                    dietGoals.carbGoal +
-                    "\nfat goal: " +
-                    dietGoals.fatGoal +
-                    "\nprotein goal: " +
-                    dietGoals.proteinGoal
-                );
                 editMacroGoalsRef.current.open({
                   calorieGoalUnits: dietGoals.calorieGoal.units,
                   calorieGoalValue: dietGoals.calorieGoal.value,

--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -6,11 +6,12 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import React from "react";
+import React, { useRef } from "react";
 import navigationService from "../../navigators/navigationService";
 import moment from "moment";
 import { sharedStyles } from "../styles";
 import * as Progress from "react-native-progress";
+import EditMacroGoalsModal from "./modals/EditMacroGoalsModal";
 
 const mealTitles = [
   {
@@ -55,7 +56,9 @@ export default function Diet({
   totalMacros,
   deleteFoodEntry,
   setMacroModalVisible,
+  getGoals,
 }) {
+  const editMacroGoalsRef = useRef(null);
   const calorieDif = dietGoals.calorieGoal.value - totalMacros.calorieCount;
   const colours = ["#ACC5CC", "#D7F6FF", "#76BBCF", "#008ab3"];
 
@@ -187,103 +190,132 @@ export default function Diet({
   };
 
   return (
-    <ScrollView
-      showsVerticalScrollIndicator={false}
-      contentContainerStyle={styles.container}
-    >
-      <View style={{ alignItems: "center" }}>
-        <View
-          style={[
-            sharedStyles.headerImageContainer,
-            {
-              backgroundColor: "rgba(202, 189, 255, 65)",
-              borderColor: "rgba(162, 151, 204, 0.7)",
-            },
-          ]}
-        >
-          <Image
-            style={sharedStyles.headerImage}
-            source={require("../../assets/images/diet.png")}
-          />
-        </View>
-      </View>
-
-      <View style={sharedStyles.datePickerView}>
-        <TouchableOpacity
-          style={sharedStyles.changeDateButton}
-          onPress={() => updateDate(-1)}
-        >
-          <Image
-            style={[sharedStyles.decreaseDateImage]}
-            source={require("../../assets/images/left.png")}
-          />
-        </TouchableOpacity>
-        <>
-          {moment(day).format("YYYYMMDD") ==
-          moment(today).format("YYYYMMDD") ? (
-            <Text style={sharedStyles.dateText}>Today</Text>
-          ) : (
-            <Text style={sharedStyles.dateText}>
-              {day.toDateString().slice(4, -5)}
-            </Text>
-          )}
-        </>
-        <TouchableOpacity
-          style={sharedStyles.changeDateButton}
-          onPress={() => updateDate(1)}
-        >
-          <Image
-            style={sharedStyles.increaseDateImage}
-            source={require("../../assets/images/left.png")}
-          />
-        </TouchableOpacity>
-      </View>
-
-      <View style={styles.borderedContainer}>
-        <View style={styles.row}>
-          <Text style={[styles.boldText, { marginBottom: 10 }]}>Macros</Text>
-          <TouchableOpacity
-            onPress={() => {
-              setMacroModalVisible(true);
-            }}
+    <>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.container}
+      >
+        <View style={{ alignItems: "center" }}>
+          <View
+            style={[
+              sharedStyles.headerImageContainer,
+              {
+                backgroundColor: "rgba(202, 189, 255, 65)",
+                borderColor: "rgba(162, 151, 204, 0.7)",
+              },
+            ]}
           >
             <Image
-              style={styles.plus}
-              source={require("../../assets/images/edit.png")}
+              style={sharedStyles.headerImage}
+              source={require("../../assets/images/diet.png")}
+            />
+          </View>
+        </View>
+
+        <View style={sharedStyles.datePickerView}>
+          <TouchableOpacity
+            style={sharedStyles.changeDateButton}
+            onPress={() => updateDate(-1)}
+          >
+            <Image
+              style={[sharedStyles.decreaseDateImage]}
+              source={require("../../assets/images/left.png")}
+            />
+          </TouchableOpacity>
+          <>
+            {moment(day).format("YYYYMMDD") ==
+            moment(today).format("YYYYMMDD") ? (
+              <Text style={sharedStyles.dateText}>Today</Text>
+            ) : (
+              <Text style={sharedStyles.dateText}>
+                {day.toDateString().slice(4, -5)}
+              </Text>
+            )}
+          </>
+          <TouchableOpacity
+            style={sharedStyles.changeDateButton}
+            onPress={() => updateDate(1)}
+          >
+            <Image
+              style={sharedStyles.increaseDateImage}
+              source={require("../../assets/images/left.png")}
             />
           </TouchableOpacity>
         </View>
-        <View style={styles.row}>
-          <Text style={styles.miniText}>Eaten</Text>
-          <Text style={styles.miniText}>
-            {calorieDif > 0 ? "Remaining" : "Exceeded"}
-          </Text>
-        </View>
-        <View style={styles.row}>
-          <Text style={styles.desc}>
-            <Text style={styles.boldText}>{totalMacros.calorieCount}</Text> kcal
-          </Text>
-          <Text style={styles.boldText}>{Math.abs(calorieDif)}</Text>
-        </View>
-        <CalorieBar />
-        <View style={[styles.row, { gap: 10 }]}>
-          {macroKeys.map((item, index) => (
-            <View style={styles.item} key={index}>
-              <MacroProgressCircle item={item} />
-              <Text style={styles.desc}>{item.title}</Text>
-            </View>
-          ))}
-        </View>
-      </View>
 
-      {mealTitles.map((item, index) =>
-        meals[item.name].entries.length > 0 ? (
-          <MealWithEntries item={item} key={index} />
-        ) : (
-          <EmptyMeal item={item} key={index} />
-        )
-      )}
-    </ScrollView>
+        <View style={styles.borderedContainer}>
+          <View style={styles.row}>
+            <Text style={[styles.boldText, { marginBottom: 10 }]}>Macros</Text>
+            <TouchableOpacity
+              onPress={() => {
+                getGoals();
+                console.log(
+                  "diet goals object: " +
+                    JSON.stringify(dietGoals) +
+                    "\ndiet goals contents in diet.js:" +
+                    "\ncalories goal: " +
+                    dietGoals.calorieGoal.value +
+                    " " +
+                    dietGoals.calorieGoal.units +
+                    "\ncarb goal: " +
+                    dietGoals.carbGoal +
+                    "\nfat goal: " +
+                    dietGoals.fatGoal +
+                    "\nprotein goal: " +
+                    dietGoals.proteinGoal
+                );
+                editMacroGoalsRef.current.open({
+                  calorieGoalUnits: dietGoals.calorieGoal.units,
+                  calorieGoalValue: dietGoals.calorieGoal.value,
+                  carbGoal: dietGoals.carbGoal,
+                  fatGoal: dietGoals.fatGoal,
+                  proteinGoal: dietGoals.proteinGoal,
+                });
+              }}
+            >
+              <Image
+                style={styles.plus}
+                source={require("../../assets/images/edit.png")}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.miniText}>Eaten</Text>
+            <Text style={styles.miniText}>
+              {calorieDif > 0 ? "Remaining" : "Exceeded"}
+            </Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.desc}>
+              <Text style={styles.boldText}>{totalMacros.calorieCount}</Text>{" "}
+              kcal
+            </Text>
+            <Text style={styles.boldText}>{Math.abs(calorieDif)}</Text>
+          </View>
+          <CalorieBar />
+          <View style={[styles.row, { gap: 10 }]}>
+            {macroKeys.map((item, index) => (
+              <View style={styles.item} key={index}>
+                <MacroProgressCircle item={item} />
+                <Text style={styles.desc}>{item.title}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {mealTitles.map((item, index) =>
+          meals[item.name].entries.length > 0 ? (
+            <MealWithEntries item={item} key={index} />
+          ) : (
+            <EmptyMeal item={item} key={index} />
+          )
+        )}
+      </ScrollView>
+      <EditMacroGoalsModal
+        getRef={(ref) => (editMacroGoalsRef.current = ref)}
+        getGoals={getGoals}
+      />
+    </>
   );
 }
 

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -236,6 +236,18 @@ const FitnessDiet = ({ navigation }) => {
     }
   };
 
+  const updateGoals = async (newGoals) => {
+    try {
+      setIsLoading(true);
+      const token = await getAccessToken();
+      await DietGoalsAPI.updateDietGoals(token, newGoals);
+      await getGoals();
+      setIsLoading(false);
+    } catch (e) {
+      errorResponse(e);
+    }
+  };
+
   const addFoodEntry = async (foodEntry) => {
     try {
       setIsLoading(true);
@@ -305,6 +317,7 @@ const FitnessDiet = ({ navigation }) => {
             deleteFoodEntry={deleteFoodEntry}
             setMacroModalVisible={setEditVisible}
             getGoals={getGoals}
+            updateGoals={updateGoals}
           />
         );
       case "third":

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -21,7 +21,6 @@ import DietGoalsAPI from "../../api/diet/dietGoalsAPI";
 import UserAPI from "../../api/user/userAPI";
 import { sharedStyles } from "../styles";
 import AddEntryModal from "./modals/AddEntryModal";
-import EditMacroGoalsModal from "./modals/EditMacroGoalsModal";
 
 const FitnessDiet = ({ navigation }) => {
   const [index, setIndex] = useState(0);

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -16,7 +16,7 @@ import { getAccessToken } from "../../user/keychain";
 import moment from "moment";
 
 import FoodEntriesMacrosAPI from "../../api/diet/foodEntriesMacrosAPI";
-import FoodEntriesAPI from "../../api/diet/foodEntriesAPI"; 
+import FoodEntriesAPI from "../../api/diet/foodEntriesAPI";
 import DietGoalsAPI from "../../api/diet/dietGoalsAPI";
 import UserAPI from "../../api/user/userAPI";
 import { sharedStyles } from "../styles";
@@ -40,7 +40,7 @@ const FitnessDiet = ({ navigation }) => {
     carbCount: 0,
     fatCount: 0,
     proteinCount: 0,
-    entries : []
+    entries: [],
   };
 
   const [breakfast, setBreakfast] = useState(defaultMacros);
@@ -49,16 +49,44 @@ const FitnessDiet = ({ navigation }) => {
   const [snack, setSnack] = useState(defaultMacros);
 
   var totalMacros = {
-    calorieCount: breakfast.calorieCount + lunch.calorieCount + dinner.calorieCount + snack.calorieCount,
-    carbCount: breakfast.carbCount + lunch.carbCount + dinner.carbCount + snack.carbCount,
-    fatCount: breakfast.fatCount + lunch.fatCount + dinner.fatCount + snack.fatCount,
-    proteinCount: breakfast.proteinCount + lunch.proteinCount + dinner.proteinCount + snack.proteinCount
+    calorieCount:
+      breakfast.calorieCount +
+      lunch.calorieCount +
+      dinner.calorieCount +
+      snack.calorieCount,
+    carbCount:
+      breakfast.carbCount +
+      lunch.carbCount +
+      dinner.carbCount +
+      snack.carbCount,
+    fatCount:
+      breakfast.fatCount + lunch.fatCount + dinner.fatCount + snack.fatCount,
+    proteinCount:
+      breakfast.proteinCount +
+      lunch.proteinCount +
+      dinner.proteinCount +
+      snack.proteinCount,
   };
 
-  const mealSetters = {breakfast: setBreakfast, lunch: setLunch, dinner: setDinner, snacks: setSnack };
-  const mealMacros = {Breakfast: breakfast, Lunch: lunch, Dinner: dinner, Snacks: snack };
+  const mealSetters = {
+    breakfast: setBreakfast,
+    lunch: setLunch,
+    dinner: setDinner,
+    snacks: setSnack,
+  };
+  const mealMacros = {
+    Breakfast: breakfast,
+    Lunch: lunch,
+    Dinner: dinner,
+    Snacks: snack,
+  };
 
-  const [dietGoals, setDietGoals] = useState({"calorieGoal": {"units": "kcal", "value": 2000}, "carbGoal": 200, "fatGoal": 67 , "proteinGoal": 150});
+  const [dietGoals, setDietGoals] = useState({
+    calorieGoal: { units: "kcal", value: 2000 },
+    carbGoal: 200,
+    fatGoal: 67,
+    proteinGoal: 150,
+  });
 
   const [dietModalVisible, setDietVisible] = useState(false);
   const [editMacroModalVisible, setEditVisible] = useState(false);
@@ -76,10 +104,7 @@ const FitnessDiet = ({ navigation }) => {
       const trackingPreferencesLoaded = (await UserAPI.getUser(token)).data
         .trackingPreferences;
 
-      await Promise.all(
-        getAllMeals(token),
-        getGoals(token)
-      );
+      await Promise.all(getAllMeals(token), getGoals(token));
 
       setTrackingPreferences(trackingPreferencesLoaded);
 
@@ -113,9 +138,9 @@ const FitnessDiet = ({ navigation }) => {
     }
   }, []);
 
-  function errorResponse(error){
+  function errorResponse(error) {
     console.log(error);
-    setIsLoading(false); 
+    setIsLoading(false);
     if (Platform.OS === "ios") {
       Toast.show("Something went wrong. Please try again.", {
         ...styles.errorToast,
@@ -132,46 +157,44 @@ const FitnessDiet = ({ navigation }) => {
   }
 
   const getAllMeals = async (token) => {
-    try{
+    try {
       setIsLoading(true);
       meals = await FoodEntriesMacrosAPI.getFoodMacrosForDay(
         token,
         moment(day).format("YYYYMMDD")
       );
-      for(const key in meals)
-      {
+      for (const key in meals) {
         mealSetters[key](meals[key]);
       }
       setIsLoading(false);
       return meals;
-    }catch (e) {
+    } catch (e) {
       errorResponse(e);
     }
   };
 
-  const getMeal = async(token, meal) => {
-    try{
+  const getMeal = async (token, meal) => {
+    try {
       setIsLoading(true);
-      if(meal in ["breakfast", "lunch", "dinner", "snack"]){
+      if (meal in ["breakfast", "lunch", "dinner", "snack"]) {
         result = await FoodEntriesMacrosAPI.getFoodMacrosForMeal(
           token,
           moment(day).format("YYYYMMDD"),
           meal
         );
 
-        mealSetters[meal](result[meal])
+        mealSetters[meal](result[meal]);
       }
       setIsLoading(false);
-
-    }catch (e) {
+    } catch (e) {
       errorResponse(e);
     }
   };
 
-  const refreshMeals = async(date = false) => {
+  const refreshMeals = async (date = false) => {
     try {
       setIsLoading(true);
-      if(!date) {
+      if (!date) {
         date = day;
       }
       token = await getAccessToken();
@@ -179,11 +202,10 @@ const FitnessDiet = ({ navigation }) => {
         token,
         moment(date).format("YYYYMMDD")
       );
-      for(key in mealSetters)
-      {
-        if(key in meals){
+      for (key in mealSetters) {
+        if (key in meals) {
           mealSetters[key](meals[key]);
-        }else{
+        } else {
           mealSetters[key](defaultMacros);
         }
       }
@@ -192,74 +214,69 @@ const FitnessDiet = ({ navigation }) => {
     } catch (e) {
       errorResponse(e);
     }
-  }
+  };
 
   const getGoals = async () => {
-    try{
+    try {
       setIsLoading(true);
       token = await getAccessToken();
       goals = await DietGoalsAPI.getDietGoals(token);
 
       len = Object.keys(goals).length;
 
-      if(len==0)
-      {
-        console.log("this person has not set up goals"); 
-      }else{
+      if (len == 0) {
+        console.log("this person has not set up goals");
+      } else {
         setDietGoals(goals);
       }
 
       setIsLoading(false);
-    }catch(e){
+    } catch (e) {
       errorResponse(e);
     }
-
   };
 
-  const addFoodEntry = async ( foodEntry ) => {
-    try{
+  const addFoodEntry = async (foodEntry) => {
+    try {
       setIsLoading(true);
       token = await getAccessToken();
       await FoodEntriesAPI.createFoodEntry(token, foodEntry);
       await getMeal(token, foodEntry["meal"]);
       setIsLoading(false);
-
-    }catch(e){
+    } catch (e) {
       errorResponse(e);
     }
-  }
+  };
 
   const deleteFoodEntry = async (foodEntry) => {
-    try{
+    try {
       setIsLoading(true);
       token = await getAccessToken();
-      try{
+      try {
         await FoodEntriesAPI.deleteFoodEntry(token, foodEntry.SK);
-      }catch(error){
+      } catch (error) {
         console.error("Error deleting food entry: " + error);
-        throw new error;
+        throw new error();
       }
       meals = await getAllMeals(token);
       setIsLoading(false);
       return meals[foodEntry.meal];
-    }catch(e){
+    } catch (e) {
       errorResponse(e);
     }
-  }
+  };
 
-  const updateFoodEntry = async ( foodEntryID, foodEntry ) => {
-    try{
+  const updateFoodEntry = async (foodEntryID, foodEntry) => {
+    try {
       setIsLoading(true);
       token = await getAccessToken();
       await FoodEntriesAPI.updateFoodEntry(token, foodEntryID, foodEntry);
       await getMeal(token, foodEntry["meal"]);
       setIsLoading(false);
-
-    }catch(e){
+    } catch (e) {
       errorResponse(e);
     }
-
-  }
+  };
 
   const renderScene = ({ route }) => {
     switch (route.key) {
@@ -279,7 +296,7 @@ const FitnessDiet = ({ navigation }) => {
       case "second":
         return (
           <Diet
-            day = {day}
+            day={day}
             updateDate={updateDate}
             meals={mealMacros}
             mealSetters={mealSetters}
@@ -287,6 +304,7 @@ const FitnessDiet = ({ navigation }) => {
             dietGoals={dietGoals}
             deleteFoodEntry={deleteFoodEntry}
             setMacroModalVisible={setEditVisible}
+            getGoals={getGoals}
           />
         );
       case "third":
@@ -332,16 +350,15 @@ const FitnessDiet = ({ navigation }) => {
           })}
         </View>
       </View>
-      <AddEntryModal 
-        isVisible={dietModalVisible} 
-        setVisible={setDietVisible} 
-        dayString={day.toLocaleDateString(undefined, { year: "numeric",  month: "long", day: "numeric"})}
+      <AddEntryModal
+        isVisible={dietModalVisible}
+        setVisible={setDietVisible}
+        dayString={day.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })}
       />
-      <EditMacroGoalsModal 
-        isVisible={editMacroModalVisible} 
-        setVisible={setEditVisible} 
-        />
-      
     </SafeAreaView>
   );
 };

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef } from "react";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
-import { Header } from "../../../components";
 import DietGoalsAPI from "../../../api/diet/dietGoalsAPI";
 import { getAccessToken } from "../../../user/keychain";
 import Spinner from "react-native-loading-spinner-overlay";
@@ -111,35 +110,14 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
     ]);
   };
 
-  //   useEffect(() => {
-  //     const getDataOnLoad = async () => {
-  //       setIsLoading(true);
-  //       setMacros();
-  //       setIsLoading(false);
-  //     };
-
-  //     getDataOnLoad();
-  //   }, []);
+  const closeModal = () => {
+    setVisible(false);
+  };
 
   useEffect(() => {
     let ref = {
       open(props) {
         setVisible(true);
-
-        console.log(
-          "diet goals contents in modal file:" +
-            "\ncalories goal: " +
-            props.calorieGoalValue +
-            " " +
-            props.calorieGoalUnits +
-            "\ncarb goal: " +
-            props.carbGoal +
-            "\nfat goal: " +
-            props.fatGoal +
-            "\nprotein goal: " +
-            props.proteinGoal +
-            "\n****************"
-        );
 
         setCalorieUnit(props.calorieGoalUnits);
         setCalories(props.calorieGoalValue);
@@ -176,10 +154,6 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
 
     getRef(ref);
   }, []);
-
-  const closeModal = async () => {
-    setVisible(false);
-  };
 
   return (
     <RNModal

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -2,27 +2,25 @@ import { useState, useEffect, useRef } from "react";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
-import DietGoalsAPI from "../../../api/diet/dietGoalsAPI";
-import { getAccessToken } from "../../../user/keychain";
 import Spinner from "react-native-loading-spinner-overlay";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
 export default function EditMacroGoalsModal({ getRef, updateGoals }) {
   const [datas, setDatas] = useState([
     {
-      title: "0 g",
+      value: "0 g",
       img: require("../../../assets/images/carbs.png"),
-      text: "Carbs:",
+      label: "Carbs:",
     },
     {
-      title: "0 g",
+      value: "0 g",
       img: require("../../../assets/images/protein.png"),
-      text: "Protein:",
+      label: "Protein:",
     },
     {
-      title: "0 g",
+      value: "0 g",
       img: require("../../../assets/images/fats.png"),
-      text: "Fats:",
+      label: "Fats:",
     },
   ]);
   const [calorieGoalValue, setCalorieGoalValue] = useState(0);
@@ -36,34 +34,34 @@ export default function EditMacroGoalsModal({ getRef, updateGoals }) {
   const [isVisible, setVisible] = useState(false);
   const updateMacrosRef = useRef(null);
 
-  const onUpdateMacroValue = async (title, value, units) => {
+  const onUpdateMacroValue = async (macroLabel, macroValue, units) => {
     var newCalories = calorieGoalValue;
     var newFats = fatGoalValue;
     var newProteins = proteinGoalValue;
     var newCarbs = carbGoalValue;
-    if (title === "Calories") {
-      setCalories(value);
+    if (macroLabel === "Calories") {
+      setCalories(macroValue);
       setCalorieUnit(units);
-      newCalories = { value: value, units: units };
+      newCalories = { value: macroValue, units: units };
       setCalorieGoalValue(newCalories);
     } else {
       let newDatas = datas.map((item) => {
-        if (item.text === title) {
-          if (title === "Carbs:") {
-            newCarbs = value;
-            setCarbGoalValue(value);
+        if (item.label === macroLabel) {
+          if (macroLabel === "Carbs:") {
+            newCarbs = macroValue;
+            setCarbGoalValue(macroValue);
           }
-          if (title === "Protein:") {
-            newProteins = value;
-            setProteinGoalValue(value);
+          if (macroLabel === "Protein:") {
+            newProteins = macroValue;
+            setProteinGoalValue(macroValue);
           }
-          if (title === "Fats:") {
-            newFats = value;
-            setFatGoalValue(value);
+          if (macroLabel === "Fats:") {
+            newFats = macroValue;
+            setFatGoalValue(macroValue);
           }
           return {
             ...item,
-            title: value + " " + units,
+            value: macroValue + " " + units,
           };
         }
         return item;
@@ -104,19 +102,19 @@ export default function EditMacroGoalsModal({ getRef, updateGoals }) {
 
         setDatas([
           {
-            title: `${Math.round(props.carbGoal)} g`,
+            value: `${Math.round(props.carbGoal)} g`,
             img: require("../../../assets/images/carbs.png"),
-            text: "Carbs:",
+            label: "Carbs:",
           },
           {
-            title: `${Math.round(props.proteinGoal)} g`,
+            value: `${Math.round(props.proteinGoal)} g`,
             img: require("../../../assets/images/protein.png"),
-            text: "Protein:",
+            label: "Protein:",
           },
           {
-            title: `${Math.round(props.fatGoal)} g`,
+            value: `${Math.round(props.fatGoal)} g`,
             img: require("../../../assets/images/fats.png"),
-            text: "Fats:",
+            label: "Fats:",
           },
         ]);
       },
@@ -164,7 +162,7 @@ export default function EditMacroGoalsModal({ getRef, updateGoals }) {
                 />
               </TouchableOpacity>
             </View>
-            <Text style={styles.calorieTitle}>
+            <Text style={styles.calorieValue}>
               {calories} {calorieUnit}
             </Text>
           </View>
@@ -172,16 +170,16 @@ export default function EditMacroGoalsModal({ getRef, updateGoals }) {
             <View style={styles.item} key={index}>
               <View style={styles.row}>
                 <Image source={item.img} style={styles.itemImg} />
-                <Text style={styles.text}>{item.text}</Text>
-                <Text style={styles.itemTitle}>{item.title}</Text>
+                <Text style={styles.text}>{item.label}</Text>
+                <Text style={styles.itemValue}>{item.value}</Text>
               </View>
               <TouchableOpacity
                 onPress={() => {
                   updateMacrosRef.current.open({
-                    title: item.text,
+                    title: item.label,
                     isCal: false,
                     units: "g",
-                    value: item.title,
+                    value: item.value,
                   });
                 }}
               >
@@ -272,13 +270,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
   },
-  itemTitle: {
+  itemValue: {
     fontSize: 16,
     fontFamily: "Sego-Bold",
     color: "#25436B",
     marginLeft: 15,
   },
-  calorieTitle: {
+  calorieValue: {
     fontFamily: "Sego-Bold",
     color: "#25436B",
     fontSize: 22,

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -8,7 +8,7 @@ import { getAccessToken } from "../../../user/keychain";
 import Spinner from "react-native-loading-spinner-overlay";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
-export default function EditMacroGoalsModal({ isVisible, setVisible }) {
+export default function EditMacroGoalsModal({ getRef, getGoals }) {
   const [datas, setDatas] = useState([
     {
       title: "0 g",
@@ -34,9 +34,11 @@ export default function EditMacroGoalsModal({ isVisible, setVisible }) {
   const [fatGoalValue, setFatGoalValue] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
+  const [isVisible, setVisible] = useState(false);
   const updateMacrosRef = useRef(null);
 
   const onUpdateMacroValue = async (title, value, units) => {
+    //gets sent into update macro modal
     var newCalories = calorieGoalValue;
     var newFats = fatGoalValue;
     var newProteins = proteinGoalValue;
@@ -109,14 +111,70 @@ export default function EditMacroGoalsModal({ isVisible, setVisible }) {
     ]);
   };
 
+  //   useEffect(() => {
+  //     const getDataOnLoad = async () => {
+  //       setIsLoading(true);
+  //       setMacros();
+  //       setIsLoading(false);
+  //     };
+
+  //     getDataOnLoad();
+  //   }, []);
+
   useEffect(() => {
-    const getDataOnLoad = async () => {
-      setIsLoading(true);
-      setMacros();
-      setIsLoading(false);
+    let ref = {
+      open(props) {
+        setVisible(true);
+
+        console.log(
+          "diet goals contents in modal file:" +
+            "\ncalories goal: " +
+            props.calorieGoalValue +
+            " " +
+            props.calorieGoalUnits +
+            "\ncarb goal: " +
+            props.carbGoal +
+            "\nfat goal: " +
+            props.fatGoal +
+            "\nprotein goal: " +
+            props.proteinGoal +
+            "\n****************"
+        );
+
+        setCalorieUnit(props.calorieGoalUnits);
+        setCalories(props.calorieGoalValue);
+        setCalorieGoalValue({
+          value: props.calorieGoalValue,
+          units: props.calorieGoalUnits,
+        });
+        setCarbGoalValue(props.carbGoal);
+        setProteinGoalValue(props.proteinGoal);
+        setFatGoalValue(props.fatGoal);
+
+        setDatas([
+          {
+            title: `${Math.round(props.carbGoal)} g`,
+            img: require("../../../assets/images/carbs.png"),
+            text: "Carbs:",
+          },
+          {
+            title: `${Math.round(props.proteinGoal)} g`,
+            img: require("../../../assets/images/protein.png"),
+            text: "Protein:",
+          },
+          {
+            title: `${Math.round(props.fatGoal)} g`,
+            img: require("../../../assets/images/fats.png"),
+            text: "Fats:",
+          },
+        ]);
+      },
+      close() {
+        setVisible(false);
+      },
     };
 
-    getDataOnLoad();
+    getRef(ref);
   }, []);
 
   const closeModal = async () => {

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -4,9 +4,10 @@ import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
 import DietGoalsAPI from "../../../api/diet/dietGoalsAPI";
 import { getAccessToken } from "../../../user/keychain";
+import Spinner from "react-native-loading-spinner-overlay";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
-export default function EditMacroGoalsModal({ getRef, getGoals }) {
+export default function EditMacroGoalsModal({ getRef, updateGoals }) {
   const [datas, setDatas] = useState([
     {
       title: "0 g",
@@ -31,6 +32,7 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
   const [proteinGoalValue, setProteinGoalValue] = useState(0);
   const [fatGoalValue, setFatGoalValue] = useState(0);
 
+  const [isLoading, setIsLoading] = useState(false);
   const [isVisible, setVisible] = useState(false);
   const updateMacrosRef = useRef(null);
 
@@ -70,43 +72,14 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
     }
   };
 
-  const setMacros = async () => {
-    const dietGoals = await DietGoalsAPI.getDietGoals(token);
-
-    setCalorieGoalValue(dietGoals.calorieGoal);
-    setCalorieUnit(dietGoals.calorieGoal.units);
-    setCalories(dietGoals.calorieGoal.value);
-    setCarbGoalValue(dietGoals.carbGoal);
-    setProteinGoalValue(dietGoals.proteinGoal);
-    setFatGoalValue(dietGoals.fatGoal);
-
-    setDatas([
-      {
-        title: `${Math.round(dietGoals.carbGoal)} g`,
-        img: require("../../../assets/images/carbs.png"),
-        text: "Carbs:",
-      },
-      {
-        title: `${Math.round(dietGoals.proteinGoal)} g`,
-        img: require("../../../assets/images/protein.png"),
-        text: "Protein:",
-      },
-      {
-        title: `${Math.round(dietGoals.fatGoal)} g`,
-        img: require("../../../assets/images/fats.png"),
-        text: "Fats:",
-      },
-    ]);
-  };
-
   const onSave = async () => {
-    const token = await getAccessToken();
-    await DietGoalsAPI.updateDietGoals(token, {
+    const newGoals = {
       carbGoal: carbGoalValue,
       proteinGoal: proteinGoalValue,
       fatGoal: fatGoalValue,
       calorieGoal: calorieGoalValue,
-    });
+    };
+    updateGoals(newGoals);
     setVisible(false);
   };
 
@@ -164,6 +137,7 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
       style={styles.modal}
     >
       <View style={styles.container}>
+        <Spinner visible={isLoading}></Spinner>
         <View style={styles.macroContainerStyle}>
           <View style={[styles.item, styles.head]}>
             <View style={[styles.item, styles.headItem]}>

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -4,7 +4,6 @@ import RNModal from "react-native-modal";
 import navigationService from "../../../navigators/navigationService";
 import DietGoalsAPI from "../../../api/diet/dietGoalsAPI";
 import { getAccessToken } from "../../../user/keychain";
-import Spinner from "react-native-loading-spinner-overlay";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 
 export default function EditMacroGoalsModal({ getRef, getGoals }) {
@@ -31,13 +30,11 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
   const [carbGoalValue, setCarbGoalValue] = useState(0);
   const [proteinGoalValue, setProteinGoalValue] = useState(0);
   const [fatGoalValue, setFatGoalValue] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
 
   const [isVisible, setVisible] = useState(false);
   const updateMacrosRef = useRef(null);
 
   const onUpdateMacroValue = async (title, value, units) => {
-    //gets sent into update macro modal
     var newCalories = calorieGoalValue;
     var newFats = fatGoalValue;
     var newProteins = proteinGoalValue;
@@ -70,14 +67,6 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
         return item;
       });
       setDatas(newDatas);
-      const token = await getAccessToken();
-      await DietGoalsAPI.updateDietGoals(token, {
-        carbGoal: newCarbs,
-        proteinGoal: newProteins,
-        fatGoal: newFats,
-        calorieGoal: newCalories,
-      });
-      setMacros();
     }
   };
 
@@ -108,6 +97,17 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
         text: "Fats:",
       },
     ]);
+  };
+
+  const onSave = async () => {
+    const token = await getAccessToken();
+    await DietGoalsAPI.updateDietGoals(token, {
+      carbGoal: carbGoalValue,
+      proteinGoal: proteinGoalValue,
+      fatGoal: fatGoalValue,
+      calorieGoal: calorieGoalValue,
+    });
+    setVisible(false);
   };
 
   const closeModal = () => {
@@ -164,7 +164,6 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
       style={styles.modal}
     >
       <View style={styles.container}>
-        <Spinner visible={isLoading}></Spinner>
         <View style={styles.macroContainerStyle}>
           <View style={[styles.item, styles.head]}>
             <View style={[styles.item, styles.headItem]}>
@@ -236,7 +235,7 @@ export default function EditMacroGoalsModal({ getRef, getGoals }) {
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.button, styles.saveButton]}
-              onPress={() => closeModal()}
+              onPress={() => onSave()}
             >
               <Text style={styles.buttonText}>Save</Text>
             </TouchableOpacity>


### PR DESCRIPTION
The macro editing modal in the diet page provides an easy way to edit specific macro values without going through the whole questionnaire, if a user prefers the option. When updating a value using the smaller modal over the edit modal, the value is reflected in the edit modal - but is not saved until/unless the user selects "save". Then, the diet page from which the modal was accessed is updated as well, reflecting any changes just made by the user. 

Changes were made to the `EditMacroGoalsModal.js`, `Diet.js` and the fitness-diet section's `index.js` files to format the modal to be more like other modals in other app sections, using `UpdateHabitStatusModal.js` and the todos-habits section's files as a reference.

Additionally, all API calls are made in `index.js`; a new function to call the `updateDietGoals` endpoint has been made, and gets passed through the diet page and into the modal to use it there. 

This PR also includes some additional minor changes to these three files to remove unnecessary imports related to this work, and the modal's file includes some variable name changes for better clarity. 

Screen recording of behaviour: 

https://github.com/user-attachments/assets/9c20e755-4dc6-47c8-954a-99bbbce09aa0