### PR TITLE
Removed excess getGoals call and modal spinner

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -56,7 +56,6 @@ export default function Diet({
   totalMacros,
   deleteFoodEntry,
   setMacroModalVisible,
-  getGoals,
   updateGoals,
 }) {
   const editMacroGoalsRef = useRef(null);
@@ -249,7 +248,6 @@ export default function Diet({
             <Text style={[styles.boldText, { marginBottom: 10 }]}>Macros</Text>
             <TouchableOpacity
               onPress={() => {
-                getGoals();
                 editMacroGoalsRef.current.open({
                   calorieGoalUnits: dietGoals.calorieGoal.units,
                   calorieGoalValue: dietGoals.calorieGoal.value,

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -315,7 +315,6 @@ const FitnessDiet = ({ navigation }) => {
             dietGoals={dietGoals}
             deleteFoodEntry={deleteFoodEntry}
             setMacroModalVisible={setEditVisible}
-            getGoals={getGoals}
             updateGoals={updateGoals}
           />
         );

--- a/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/EditMacroGoalsModal.js
@@ -135,7 +135,6 @@ export default function EditMacroGoalsModal({ getRef, updateGoals }) {
       style={styles.modal}
     >
       <View style={styles.container}>
-        <Spinner visible={isLoading}></Spinner>
         <View style={styles.macroContainerStyle}>
           <View style={[styles.item, styles.head]}>
             <View style={[styles.item, styles.headItem]}>


### PR DESCRIPTION
Removed the following:
- spinner in `EditMacroGoalsModal.js` to improve perfromance on iOS devices, as there are known issues with timing related to the use of spinners in modals 
- call to getGoals/the `getDietGoals` endpoint in `Diet.js` to reduce the amount of calls that are being made to the backend
- passing in getGoals (the function calling the API endpoint) from `index.js` to `Diet.js`

Screen recording of behaviour - no observable changes or issues after the removal of these:

https://github.com/user-attachments/assets/0c31d423-8fb8-4e94-ab16-9b06f14f9438