### PR TITLE
connected add entry to meal page's "add food" button

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -74,7 +74,14 @@ export default function Diet({
     >
       <View style={[styles.row, { marginBottom: 0 }]}>
         <Text style={styles.itemText}>{item?.name}</Text>
-        <TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => {
+            navigationService.navigate("searchFood", {
+              mealName: item?.name,
+              dayString: day.toISOString(),
+            });
+          }}
+        >
           <Image
             style={styles.plus}
             source={require("../../assets/images/plus512.png")}

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -22,6 +22,7 @@ const MealPage = ({ navigation, route }) => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [isLoading, setIsLoading] = useState(false);
   const foodEntriesChangedRef = useRef(false);
+  var refreshMeal = route.params?.refreshMeal || null;
 
   var mealImage;
   if (mealName === "Breakfast") {
@@ -61,6 +62,7 @@ const MealPage = ({ navigation, route }) => {
       mealName: mealName,
       dayString: currentDate.toISOString(),
       prevPage: "mealPage",
+      meal: currentMeal,
     });
   };
 
@@ -114,9 +116,14 @@ const MealPage = ({ navigation, route }) => {
       <View style={styles.topArea}>
         <TouchableOpacity
           onPress={() => {
-            navigationService.navigate("fitness-diet", {
+            var params = {
               foodItemsChanged: foodEntriesChangedRef.current,
-            });
+            };
+
+            if (refreshMeal != null) {
+              params["refreshMeal"] = refreshMeal;
+            }
+            navigationService.navigate("fitness-diet", params);
           }}
         >
           <Image

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -93,6 +93,10 @@ const MealPage = ({ navigation, route }) => {
       updatedMeal.entries = updatedMeal.entries.filter(
         (item) => item.SK !== foodEntry.SK
       );
+      updatedMeal.calorieCount -= foodEntry.calorieCount;
+      updatedMeal.carbCount -= foodEntry.carbCount;
+      updatedMeal.proteinCount -= foodEntry.proteinCount;
+      updatedMeal.fatCount -= foodEntry.fatCount;
 
       token = await getAccessToken();
       await FoodEntriesAPI.deleteFoodEntry(token, foodEntry.SK);

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -57,12 +57,11 @@ const MealPage = ({ navigation, route }) => {
   };
 
   const addMealItem = () => {
-    const newFood = {
-      id: mealItemCount,
-      name: "Eggs and bacon",
-      calorieCount: 100,
-    };
-    mealSetter([...meal.entries, newFood]);
+    navigationService.navigate("searchFood", {
+      mealName: mealName,
+      dayString: currentDate.toISOString(),
+      prevPage: "mealPage",
+    });
   };
 
   const deleteMealItem = async (mealItem) => {

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -16,6 +16,7 @@ import Spinner from "react-native-loading-spinner-overlay";
 import AddEntryModal from "../modals/AddEntryModal";
 
 const SearchFood = ({ navigation, route }) => {
+  var prevPage = route.params?.prevPage || "fitness-diet";
   const mealName = route.params.mealName;
   const dayString = route.params.dayString;
   const day = new Date(dayString);
@@ -81,7 +82,7 @@ const SearchFood = ({ navigation, route }) => {
         <Spinner visible={isLoading}></Spinner>
         <TouchableOpacity
           onPress={() => {
-            navigationService.navigate("fitness-diet");
+            navigationService.navigate(prevPage);
           }}
         >
           <Image
@@ -150,6 +151,7 @@ const SearchFood = ({ navigation, route }) => {
           getRef={(ref) => (addEntryRef.current = ref)}
           mealName={mealName}
           day={day}
+          prevPage={prevPage}
         />
       </View>
     </SafeAreaView>

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -17,6 +17,7 @@ import AddEntryModal from "../modals/AddEntryModal";
 
 const SearchFood = ({ navigation, route }) => {
   var prevPage = route.params?.prevPage || "fitness-diet";
+  var mealMacros = route.params?.meal || null;
   const mealName = route.params.mealName;
   const dayString = route.params.dayString;
   const day = new Date(dayString);
@@ -82,7 +83,13 @@ const SearchFood = ({ navigation, route }) => {
         <Spinner visible={isLoading}></Spinner>
         <TouchableOpacity
           onPress={() => {
-            navigationService.navigate(prevPage);
+            var params = {};
+            if (prevPage == "mealPage") {
+              params["dateString"] = day.toLocaleDateString();
+              params["mealName"] = mealName;
+              params["meal"] = mealMacros;
+            }
+            navigationService.navigate(prevPage, params);
           }}
         >
           <Image
@@ -152,6 +159,7 @@ const SearchFood = ({ navigation, route }) => {
           mealName={mealName}
           day={day}
           prevPage={prevPage}
+          meal={mealMacros}
         />
       </View>
     </SafeAreaView>

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -120,10 +120,7 @@ export default function AddEntryModal({
         meal.proteinCount += newFoodEntry.proteinCount;
         meal.carbCount += newFoodEntry.carbCount;
         meal.fatCount += newFoodEntry.fatCount;
-        meal.entries.push({
-          name: foodEntry.name,
-          calorieCount: newFoodEntry.calorieCount,
-        });
+        meal.entries.push(newFoodEntry);
 
         params["dateString"] = day.toLocaleDateString();
         params["mealName"] = mealName;

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -43,7 +43,8 @@ const macroTitles = [
   },
 ];
 
-export default function AddEntryModal({ getRef, mealName, day }) {
+export default function AddEntryModal({ getRef, mealName, day, prevPage }) {
+  var prev = prevPage;
   const [isVisible, setVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [foodEntry, setFoodEntry] = useState({
@@ -103,7 +104,7 @@ export default function AddEntryModal({ getRef, mealName, day }) {
       await FoodEntriesAPI.createFoodEntry(token, newFoodEntry);
       setIsLoading(false);
       setVisible(false);
-      navigationService.navigate("fitness-diet", {
+      navigationService.navigate(prev, {
         refreshMeal: mealName.toLowerCase(),
       });
     } catch (e) {

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -43,8 +43,13 @@ const macroTitles = [
   },
 ];
 
-export default function AddEntryModal({ getRef, mealName, day, prevPage }) {
-  var prev = prevPage;
+export default function AddEntryModal({
+  getRef,
+  mealName,
+  day,
+  prevPage,
+  meal,
+}) {
   const [isVisible, setVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [foodEntry, setFoodEntry] = useState({
@@ -102,11 +107,30 @@ export default function AddEntryModal({ getRef, mealName, day, prevPage }) {
       setIsLoading(true);
       token = await getAccessToken();
       await FoodEntriesAPI.createFoodEntry(token, newFoodEntry);
+
       setIsLoading(false);
       setVisible(false);
-      navigationService.navigate(prev, {
+
+      var params = {
         refreshMeal: mealName.toLowerCase(),
-      });
+      };
+
+      if (prevPage == "mealPage") {
+        meal.calorieCount += newFoodEntry.calorieCount;
+        meal.proteinCount += newFoodEntry.proteinCount;
+        meal.carbCount += newFoodEntry.carbCount;
+        meal.fatCount += newFoodEntry.fatCount;
+        meal.entries.push({
+          name: foodEntry.name,
+          calorieCount: newFoodEntry.calorieCount,
+        });
+
+        params["dateString"] = day.toLocaleDateString();
+        params["mealName"] = mealName;
+        params["meal"] = meal;
+      }
+
+      navigationService.navigate(prevPage, params);
     } catch (e) {
       console.log(e);
       setIsLoading(false);


### PR DESCRIPTION
Changes made:
- made search page appear when add food is pressed in meal page
- passed in the name of the page that navigated to so it doesnt always go back to the diet/fitness home screen
- modified the delete food entry so that it updates the macros on the meal page, previously it just removed itself from the list of entries 
- linked the an empty meal's "+" icon to the search page

Add entry from meal page:
https://github.com/user-attachments/assets/b6625e9b-ec25-4e9c-962f-c4171132551b

Add entry from main screen:
https://github.com/user-attachments/assets/631a6b51-faa1-453d-a43b-4286c38d65c0

I modified the delete entry function so that the macros reflect the new changes:
https://github.com/user-attachments/assets/d2295144-403a-4c43-bf13-55ff5a178af7

"+" icon" 
https://github.com/user-attachments/assets/ae74d556-b9e6-4976-b806-59661b2bcb7f







