### PR TITLE
Automatic barcode scanning

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
@@ -1,12 +1,14 @@
 import { Camera, CameraView, useCameraPermissions } from "expo-camera";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { StyleSheet, TouchableOpacity, View, Image, Alert } from "react-native";
-import navigationService from "../../../navigators/navigationService";
+import { useFocusEffect } from "@react-navigation/native";
 import Toast from "react-native-root-toast";
+import navigationService from "../../../navigators/navigationService";
 
 const BarcodeCamera = ({ route }) => {
   const [permission, requestPermission] = useCameraPermissions();
   const [flash, setFlash] = useState("off");
+  const [barcodeData, setBarcodeData] = useState(null);
 
   if (!permission) {
     // Camera permissions are still loading.
@@ -33,6 +35,13 @@ const BarcodeCamera = ({ route }) => {
       }
     );
   }
+
+  useFocusEffect(
+    useCallback(() => {
+      //Reset stored barcode data when the screen re-opens
+      setBarcodeData(null);
+    }, [])
+  );
 
   const toggleFlash = () => {
     if (flash === "off") {

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
@@ -51,33 +51,31 @@ const BarcodeCamera = ({ route }) => {
   const handleScannedResult = (barcodeScanningResult) => {
     if (!scanned) {
       setScanned(true);
-      navigationService.navigate("searchFood", {
-        prevPage: route.params.prevPage,
-        meal: route.params.meal,
-        mealName: route.params.mealName,
-        dayString: route.params.dayString,
-        barcodeData: {
-          type: barcodeScanningResult.type,
-          data: barcodeScanningResult.data,
-        },
-      });
+      exitPage(barcodeScanningResult);
       setTimeout(() => setScanned(false), 3000);
     }
   };
 
-  const exitPage = () => {
-    navigationService.navigate("searchFood", {
+  const exitPage = (barcodeScanningResult) => {
+    var params = {
       prevPage: route.params.prevPage,
       meal: route.params.meal,
       mealName: route.params.mealName,
       dayString: route.params.dayString,
-    });
+    };
+    if (barcodeScanningResult != null) {
+      params["barcodeData"] = {
+        type: barcodeScanningResult.type,
+        data: barcodeScanningResult.data,
+      };
+    }
+    navigationService.navigate("searchFood", params);
   };
 
   return (
     <View style={styles.container}>
       <View style={[styles.banner, styles.topArea]}>
-        <TouchableOpacity onPress={() => exitPage()}>
+        <TouchableOpacity onPress={() => exitPage(null)}>
           <Image
             style={styles.backArrow}
             source={require("../../../assets/images/back-arrow.png")}

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
@@ -8,7 +8,7 @@ import navigationService from "../../../navigators/navigationService";
 const BarcodeCamera = ({ route }) => {
   const [permission, requestPermission] = useCameraPermissions();
   const [flash, setFlash] = useState("off");
-  const [barcodeData, setBarcodeData] = useState(null);
+  // const [barcodeData, setBarcodeData] = useState(null);
   if (!permission) {
     // Camera permissions are still loading.
     return <View />;
@@ -49,22 +49,19 @@ const BarcodeCamera = ({ route }) => {
   };
 
   const handleScannedResult = (barcodeScanningResult) => {
-    //version 1: update state var + console.log + set timeout
-    if (barcodeData === null) {
-      console.log("Result =\n" + JSON.stringify(barcodeScanningResult));
-      setBarcodeData({
+    navigationService.navigate("searchFood", {
+      prevPage: route.params.prevPage,
+      meal: route.params.meal,
+      mealName: route.params.mealName,
+      dayString: route.params.dayString,
+      barcodeData: {
         type: barcodeScanningResult.type,
         data: barcodeScanningResult.data,
-      });
+      },
+    });
 
-      console.log("Barcode data =\n" + JSON.stringify(barcodeData));
-      setTimeout(() => setBarcodeData(null), 3000);
-      console.log("Ready to scan again");
-    }
-
-    //version 2: navigate using code in this function
-    //version 3: navigate using exitPage
-    //version 4: navigate without a state var, just passing in the result?
+    setTimeout(() => 3000);
+    console.log("Ready to scan again");
   };
 
   const exitPage = () => {

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
@@ -1,5 +1,5 @@
-import { Camera, CameraView, useCameraPermissions } from "expo-camera";
-import { useState, useCallback } from "react";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import { useState } from "react";
 import { StyleSheet, TouchableOpacity, View, Image, Alert } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import Toast from "react-native-root-toast";
@@ -9,7 +9,6 @@ const BarcodeCamera = ({ route }) => {
   const [permission, requestPermission] = useCameraPermissions();
   const [flash, setFlash] = useState("off");
   const [barcodeData, setBarcodeData] = useState(null);
-
   if (!permission) {
     // Camera permissions are still loading.
     return <View />;
@@ -36,13 +35,6 @@ const BarcodeCamera = ({ route }) => {
     );
   }
 
-  useFocusEffect(
-    useCallback(() => {
-      //Reset stored barcode data when the screen re-opens
-      setBarcodeData(null);
-    }, [])
-  );
-
   const toggleFlash = () => {
     if (flash === "off") {
       setFlash("on");
@@ -54,6 +46,25 @@ const BarcodeCamera = ({ route }) => {
       duration: Toast.durations.SHORT,
       position: Toast.positions.CENTER,
     });
+  };
+
+  const handleScannedResult = (barcodeScanningResult) => {
+    //version 1: update state var + console.log + set timeout
+    if (barcodeData === null) {
+      console.log("Result =\n" + JSON.stringify(barcodeScanningResult));
+      setBarcodeData({
+        type: barcodeScanningResult.type,
+        data: barcodeScanningResult.data,
+      });
+
+      console.log("Barcode data =\n" + JSON.stringify(barcodeData));
+      setTimeout(() => setBarcodeData(null), 3000);
+      console.log("Ready to scan again");
+    }
+
+    //version 2: navigate using code in this function
+    //version 3: navigate using exitPage
+    //version 4: navigate without a state var, just passing in the result?
   };
 
   const exitPage = () => {
@@ -81,7 +92,14 @@ const BarcodeCamera = ({ route }) => {
           ></Image>
         </TouchableOpacity>
       </View>
-      <CameraView style={styles.camera} flash={flash}></CameraView>
+      <CameraView
+        style={styles.camera}
+        flash={flash}
+        barcodeScannerSettings={{
+          barcodetypes: ["ean13", "ean8", "upc_e", "upc_a"],
+        }}
+        onBarcodeScanned={handleScannedResult}
+      ></CameraView>
       <View style={styles.banner}>
         <TouchableOpacity>
           <Image

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/BarcodeCamera.js
@@ -1,14 +1,14 @@
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { useState } from "react";
 import { StyleSheet, TouchableOpacity, View, Image, Alert } from "react-native";
-import { useFocusEffect } from "@react-navigation/native";
 import Toast from "react-native-root-toast";
 import navigationService from "../../../navigators/navigationService";
 
 const BarcodeCamera = ({ route }) => {
   const [permission, requestPermission] = useCameraPermissions();
   const [flash, setFlash] = useState("off");
-  // const [barcodeData, setBarcodeData] = useState(null);
+  const [scanned, setScanned] = useState(false);
+
   if (!permission) {
     // Camera permissions are still loading.
     return <View />;
@@ -49,19 +49,20 @@ const BarcodeCamera = ({ route }) => {
   };
 
   const handleScannedResult = (barcodeScanningResult) => {
-    navigationService.navigate("searchFood", {
-      prevPage: route.params.prevPage,
-      meal: route.params.meal,
-      mealName: route.params.mealName,
-      dayString: route.params.dayString,
-      barcodeData: {
-        type: barcodeScanningResult.type,
-        data: barcodeScanningResult.data,
-      },
-    });
-
-    setTimeout(() => 3000);
-    console.log("Ready to scan again");
+    if (!scanned) {
+      setScanned(true);
+      navigationService.navigate("searchFood", {
+        prevPage: route.params.prevPage,
+        meal: route.params.meal,
+        mealName: route.params.mealName,
+        dayString: route.params.dayString,
+        barcodeData: {
+          type: barcodeScanningResult.type,
+          data: barcodeScanningResult.data,
+        },
+      });
+      setTimeout(() => setScanned(false), 3000);
+    }
   };
 
   const exitPage = () => {

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -19,9 +19,6 @@ const SearchFood = ({ navigation, route }) => {
   var prevPage = route.params?.prevPage || "fitness-diet";
   var mealMacros = route.params?.meal || null;
   var barcodeData = route.params?.barcodeData || null;
-  console.log(
-    "Refreshed search page, barcodeData = " + JSON.stringify(barcodeData)
-  );
   const mealName = route.params.mealName;
   const dayString = route.params.dayString;
   const day = new Date(dayString);
@@ -50,15 +47,6 @@ const SearchFood = ({ navigation, route }) => {
   useEffect(() => {
     getFoodItems(token);
   }, []);
-
-  useEffect(() => {
-    barcodeData = route.params?.barcodeData;
-    if (barcodeData != null) {
-      console.log(
-        "Sensed change to barcodeData; now = " + JSON.stringify(barcodeData)
-      );
-    }
-  }, [route]);
 
   function errorResponse(error) {
     console.log(error);

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -19,7 +19,9 @@ const SearchFood = ({ navigation, route }) => {
   var prevPage = route.params?.prevPage || "fitness-diet";
   var mealMacros = route.params?.meal || null;
   var barcodeData = route.params?.barcodeData || null;
-  console.log("In search page, barcodeData = " + JSON.stringify(barcodeData));
+  console.log(
+    "Refreshed search page, barcodeData = " + JSON.stringify(barcodeData)
+  );
   const mealName = route.params.mealName;
   const dayString = route.params.dayString;
   const day = new Date(dayString);
@@ -50,10 +52,6 @@ const SearchFood = ({ navigation, route }) => {
   }, []);
 
   useEffect(() => {
-    console.log(
-      "In useEffect, sensed change; value now = " +
-        JSON.stringify(route.params?.barcodeData)
-    );
     barcodeData = route.params?.barcodeData;
     if (barcodeData != null) {
       console.log(

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -18,6 +18,8 @@ import AddEntryModal from "../modals/AddEntryModal";
 const SearchFood = ({ navigation, route }) => {
   var prevPage = route.params?.prevPage || "fitness-diet";
   var mealMacros = route.params?.meal || null;
+  var barcodeData = route.params?.barcodeData || null;
+  console.log("In search page, barcodeData = " + JSON.stringify(barcodeData));
   const mealName = route.params.mealName;
   const dayString = route.params.dayString;
   const day = new Date(dayString);
@@ -46,6 +48,19 @@ const SearchFood = ({ navigation, route }) => {
   useEffect(() => {
     getFoodItems(token);
   }, []);
+
+  useEffect(() => {
+    console.log(
+      "In useEffect, sensed change; value now = " +
+        JSON.stringify(route.params?.barcodeData)
+    );
+    barcodeData = route.params?.barcodeData;
+    if (barcodeData != null) {
+      console.log(
+        "Sensed change to barcodeData; now = " + JSON.stringify(barcodeData)
+      );
+    }
+  }, [route]);
 
   function errorResponse(error) {
     console.log(error);


### PR DESCRIPTION
Using the barcode scanning functionality in the [Expo Camera documentation](https://docs.expo.dev/versions/v51.0.0/sdk/camera/), a user can place any item with a barcode of the following types in front of their device back camera and it will _automatically_ register the barcode and pass its type and number to the search page: 
- UPC-E (Canada/USA, 12 digits)
- UPC-A (Canada/USA, 8 digits)
- EAN-13 (Europe/Asia/Latin America, 13 digits)
- EAN-8 (Europe/Asia/Latin America, 8 digits)

These have all been tested with real food items with barcodes except for EAN-8. The barcode scanning was also successful in lower light conditions, with sideways and upside down items, and with slightly scrunched or deformed barcodes. In the worst case scenarios they needed a few tries to be scanned successfully, but they usually worked on the first try. 

In the search page, the data is only sent in when scanned, defaulting to sending in undefined or null otherwise. 

Screen recording of functionality, with a toast added temporarily (not included in this PR) to show that data is being properly passed into the search page:

https://github.com/user-attachments/assets/93520705-e273-4d12-bde9-a73b377b60a2