### PR TITLE
Aligned content inside progress circles

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/Diet.js
+++ b/mobile-app/src/screens/Fitness-Diet/Diet.js
@@ -151,13 +151,14 @@ export default function Diet({
           color={outerColor}
           borderWidth={1}
           borderColor="#ACC5CC"
-        />
-        <View style={styles.progressCirlceContent}>
-          <Text style={[styles.boldText, { fontSize: 22 }]}>
-            {totalMacros[item.consumed]}g
-          </Text>
-          <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
-        </View>
+        >
+          <View style={styles.progressCircleContent}>
+            <Text style={[styles.boldText, { fontSize: 22 }]}>
+              {totalMacros[item.consumed]}g
+            </Text>
+            <Text style={styles.miniText}>/{dietGoals[item.goal]}g</Text>
+          </View>
+        </Progress.Circle>
       </View>
     );
   };
@@ -452,7 +453,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
   },
-  progressCirlceContent: {
+  progressCircleContent: {
     position: "absolute",
     width: "100%",
     height: "100%",


### PR DESCRIPTION
On Android (Samsung Galaxy S24), the text of the macros tracked and the macro goals for fats, carbs and proteins was slightly off center; the right side of the text (the grams g label) would be very close to or touch the right side of the progress circle, especially with 3 digit numbers. This is what this looked like with partially accomplished goals and exceeded goals:
![progress circle old partial](https://github.com/user-attachments/assets/47a0c5fa-ff5b-456b-9712-23e0749a569e)
![progress circle old exceeded](https://github.com/user-attachments/assets/5d34b8da-952f-48ef-bcc5-cdf005292c1e)

After my changes, the text is centered regardless of the goal progress:
![progress circle new empty](https://github.com/user-attachments/assets/478c28c7-6e5d-4eb3-a6ad-14040c999b84)
![progress circle new partial](https://github.com/user-attachments/assets/df31e93b-22a2-4220-b65d-a8d95ed6b492)
![progress circle new exceeded](https://github.com/user-attachments/assets/7e37cd6a-c8bc-4635-ba99-00d5510ccb4d)

This also aligns on iOS:
![progress circle new partial ios](https://github.com/user-attachments/assets/8ca7fc25-a0c7-4677-9fed-63cd3298a42a)
