### PR TITLE
Fix to duplicate entry issue

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -62,7 +62,7 @@ const MealPage = ({ navigation, route }) => {
       mealName: mealName,
       dayString: currentDate.toISOString(),
       prevPage: "mealPage",
-      meal: currentMeal,
+      meal: JSON.parse(JSON.stringify(currentMeal)),
     });
   };
 


### PR DESCRIPTION
Issue was when adding the first entry to a meal with no entries through the meal page, the entries would visually add to every other meal with no entries. Fix involves passing a deep copy of the meal macro object to the search page, so when altering the meal (so that it would display the new entry on the meal page without needing to make more api calls than needed) it wouldn't alter the default meal object directly that is being referenced by the other meals. 


https://github.com/user-attachments/assets/f54dcf76-0bd6-462e-8a4b-a3587cfddf2a

