### PR TITLE
AddEntryModal - Display Alternate Serving Options

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -18,8 +18,7 @@ import Spinner from "react-native-loading-spinner-overlay";
 import DropDownPicker from "react-native-dropdown-picker";
 
 //TO DOs:
-//1. replace serving from textinput to dropdown - requires an import as select component isnt built into react
-//2. maybe: make a call to the api to get further details like serving options (?) - will need to decide later as we integrate with our selected third party database
+//1. maybe: make a call to the api to get further details like serving options (?) - will need to decide later as we integrate with our selected third party database
 
 const macroTitles = [
   {
@@ -66,19 +65,6 @@ export default function AddEntryModal({
 
   const [quantity, setQuantity] = useState();
   const [serving, setServing] = useState();
-  var currentMacros = {
-    Fats: +((foodEntry.fatCount / foodEntry.quantity) * quantity).toFixed(2),
-    Protein: +((foodEntry.carbCount / foodEntry.quantity) * quantity).toFixed(
-      2
-    ),
-    Carbs: +((foodEntry.proteinCount / foodEntry.quantity) * quantity).toFixed(
-      2
-    ),
-    Calories: +(
-      (foodEntry.calorieCount / foodEntry.quantity) *
-      quantity
-    ).toFixed(2),
-  };
 
   const [selectOpen, setSelectOpen] = useState(false);
   const [selectedServing, setSelectedServing] = useState();
@@ -93,19 +79,31 @@ export default function AddEntryModal({
     name: "",
     proteinCount: 0,
     quantity: 1,
-  }); //i dont think this needs to exist - but we will see
+  });
+
+  var currentMacros = {
+    Fats: +((baseMacros.fatCount / baseMacros.quantity) * quantity).toFixed(2),
+    Protein: +(
+      (baseMacros.proteinCount / baseMacros.quantity) *
+      quantity
+    ).toFixed(2),
+    Carbs: +((baseMacros.carbCount / baseMacros.quantity) * quantity).toFixed(
+      2
+    ),
+    Calories: +(
+      (baseMacros.calorieCount / baseMacros.quantity) *
+      quantity
+    ).toFixed(2),
+  };
 
   useEffect(() => {
     let ref = {
       open(foodEntry) {
-        setQuantity(`${+foodEntry.quantity}`);
-        setServing(`${foodEntry.measurement}`);
         setFoodEntry(foodEntry);
-        setBaseMacros(foodEntry);
         setVisible(true);
         setSelectOpen(false);
 
-        //serving options
+        //serving options related
         var details = [];
         var options =
           foodEntry?.altServings == null ? [foodEntry] : foodEntry.altServings;
@@ -116,6 +114,9 @@ export default function AddEntryModal({
 
         setLabels(options);
         setSelectedServing(options[0].value);
+        setBaseMacros(details[0]);
+        setQuantity(`${+details[0].quantity}`);
+        setServing(`${details[0].measurement}`);
         setDetails(details);
       },
       close() {
@@ -207,22 +208,15 @@ export default function AddEntryModal({
                   value={selectedServing}
                   setValue={setSelectedServing}
                   items={servingLabels}
-                  setItems={setLabels}
                   onSelectItem={(item) => {
-                    console.log(servingsDetails[item.value]);
+                    setServing(item.label);
                     setBaseMacros(servingsDetails[item.value]);
+                    setQuantity(`${+servingsDetails[item.value].quantity}`);
                   }}
+                  onOpen={() => Keyboard.dismiss()}
                   style={[styles.borderedContainer]}
-                  dropDownContainerStyle={{
-                    borderColor: "rgba(172, 197, 204, 0.75)",
-                    borderWidth: 2,
-                    maxHeight: 80,
-                  }}
-                  textStyle={{
-                    fontFamily: "Sego-Bold",
-                    color: "#25436B",
-                    fontSize: 12,
-                  }}
+                  dropDownContainerStyle={styles.dropdownContainer}
+                  textStyle={styles.selectText}
                   itemSeparator={true}
                   itemSeparatorStyle={{
                     backgroundColor: "rgba(172, 197, 204, 0.75)",
@@ -235,7 +229,7 @@ export default function AddEntryModal({
               <Text style={styles.rowText}>Quantity: </Text>
               <TextInput
                 style={[styles.borderedContainer, styles.input]}
-                inputMode="numeric"
+                inputMode="decimal"
                 onChangeText={setQuantity}
                 value={quantity}
                 textAlign={"center"}
@@ -250,7 +244,7 @@ export default function AddEntryModal({
             >
               <View style={styles.row}>
                 <Image style={styles.icon} source={item.icon} />
-                <Text style={styles.buttonText}>{item.name}</Text>
+                <Text style={styles.rowText}>{item.name}</Text>
               </View>
 
               <Text style={[styles.rowText, { fontFamily: "Sego-Bold" }]}>
@@ -266,7 +260,7 @@ export default function AddEntryModal({
                 setVisible(false);
               }}
             >
-              <Text style={[styles.buttonText]}>Cancel</Text>
+              <Text style={[styles.rowText]}>Cancel</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[
@@ -278,7 +272,7 @@ export default function AddEntryModal({
                 addFoodEntry();
               }}
             >
-              <Text style={[styles.buttonText]}>Add</Text>
+              <Text style={[styles.rowText]}>Add</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -335,11 +329,6 @@ const styles = StyleSheet.create({
     alignContent: "center",
     marginTop: 20,
   },
-  buttonText: {
-    fontSize: 22,
-    fontFamily: "Sego",
-    color: "#25436B",
-  },
   macroContainer: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -347,12 +336,23 @@ const styles = StyleSheet.create({
     paddingHorizontal: 15,
   },
   input: {
-    width: "40%",
+    width: "60%",
     fontSize: 20,
     fontFamily: "Sego-Bold",
     color: "#25436B",
   },
   serving: {
     marginBottom: 20,
+  },
+  selectText: {
+    color: "#25436B",
+    fontSize: 12,
+    textAlign: "center",
+    fontFamily: "Sego-Bold",
+  },
+  dropdownContainer: {
+    borderColor: "rgba(172, 197, 204, 0.75)",
+    borderWidth: 2,
+    maxHeight: 80,
   },
 });

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -15,6 +15,7 @@ import FoodEntriesAPI from "../../../api/diet/foodEntriesAPI";
 import { getAccessToken } from "../../../user/keychain";
 import moment from "moment";
 import Spinner from "react-native-loading-spinner-overlay";
+import DropDownPicker from "react-native-dropdown-picker";
 
 //TO DOs:
 //1. replace serving from textinput to dropdown - requires an import as select component isnt built into react
@@ -79,13 +80,43 @@ export default function AddEntryModal({
     ).toFixed(2),
   };
 
+  const [selectOpen, setSelectOpen] = useState(false);
+  const [selectedServing, setSelectedServing] = useState();
+  const [servingLabels, setLabels] = useState();
+  const [servingsDetails, setDetails] = useState();
+  const [baseMacros, setBaseMacros] = useState({
+    calorieCount: 0,
+    carbCount: 0,
+    fatCount: 0,
+    meal: "dinner",
+    measurement: "cup",
+    name: "",
+    proteinCount: 0,
+    quantity: 1,
+  }); //i dont think this needs to exist - but we will see
+
   useEffect(() => {
     let ref = {
       open(foodEntry) {
         setQuantity(`${+foodEntry.quantity}`);
         setServing(`${foodEntry.measurement}`);
         setFoodEntry(foodEntry);
+        setBaseMacros(foodEntry);
         setVisible(true);
+        setSelectOpen(false);
+
+        //serving options
+        var details = [];
+        var options =
+          foodEntry?.altServings == null ? [foodEntry] : foodEntry.altServings;
+        options = options.map((item, index) => {
+          details.push(item);
+          return { label: item.measurement, value: index };
+        });
+
+        setLabels(options);
+        setSelectedServing(options[0].value);
+        setDetails(details);
       },
       close() {
         setVisible(false);
@@ -157,19 +188,47 @@ export default function AddEntryModal({
       backdropOpacity={0}
       style={styles.modal}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <TouchableWithoutFeedback
+        onPress={() => {
+          Keyboard.dismiss();
+          setSelectOpen(false);
+        }}
+      >
         <View style={styles.container}>
           <Text style={styles.titleText}>{foodEntry.name} </Text>
           <Spinner visible={isLoading}></Spinner>
           <View style={styles.serving}>
-            <View style={styles.row}>
-              <Text style={styles.rowText}>Serving Size: </Text>
-              <TextInput
-                style={[styles.borderedContainer, styles.input]}
-                onChangeText={setServing}
-                value={serving}
-                textAlign={"center"}
-              />
+            <View style={[styles.row, { zIndex: 1000 }]}>
+              <Text style={styles.rowText}>Serving: </Text>
+              <View style={{ width: "60%" }}>
+                <DropDownPicker
+                  open={selectOpen}
+                  setOpen={setSelectOpen}
+                  value={selectedServing}
+                  setValue={setSelectedServing}
+                  items={servingLabels}
+                  setItems={setLabels}
+                  onSelectItem={(item) => {
+                    console.log(servingsDetails[item.value]);
+                    setBaseMacros(servingsDetails[item.value]);
+                  }}
+                  style={[styles.borderedContainer]}
+                  dropDownContainerStyle={{
+                    borderColor: "rgba(172, 197, 204, 0.75)",
+                    borderWidth: 2,
+                    maxHeight: 80,
+                  }}
+                  textStyle={{
+                    fontFamily: "Sego-Bold",
+                    color: "#25436B",
+                    fontSize: 12,
+                  }}
+                  itemSeparator={true}
+                  itemSeparatorStyle={{
+                    backgroundColor: "rgba(172, 197, 204, 0.75)",
+                  }}
+                />
+              </View>
             </View>
 
             <View style={styles.row}>


### PR DESCRIPTION
Displays the alternate serving options provided by fatSecret in the form of a dropdown in the AddEntryModal. 

New State variables:
- selectOpen: controls whether the dropdown is open
- selectedServing: contains the value (in this case the index in the details array) of the selected option
- servingLabels: the list of serving options, formatted as {label: , value: }.
- servingsDetails: due to the value in the list of serving options not being able to contain an object (must be a numerical value or a string), I opted to put the serving details in a separate array.
- baseMacros: this stores the default macro values given by a serving option

Will need a follow up PR to get the alternate servings when looking at the details of a previous entry. This will include a new API code and to add a field to the entry to indicate if it is from fatSecret. 


https://github.com/user-attachments/assets/a8fb2e38-2153-4671-84fa-d6cd6c55e480



