### PR TITLE
Save serving details in foodEntry

### DIFF
--- a/backend/tracker-diet/foodEntries/createFoodEntry.js
+++ b/backend/tracker-diet/foodEntries/createFoodEntry.js
@@ -45,7 +45,7 @@ class CreateFoodEntry {
       carbCount: foodEntry.carbCount,
       quantity: foodEntry.quantity,
       measurement: foodEntry.measurement,
-      altServings: foodEntry.altServings,
+      servingsDetails: foodEntry.servingsDetails,
     };
 
     await this.DB.putItem(data);

--- a/backend/tracker-diet/foodEntries/createFoodEntry.js
+++ b/backend/tracker-diet/foodEntries/createFoodEntry.js
@@ -45,6 +45,7 @@ class CreateFoodEntry {
       carbCount: foodEntry.carbCount,
       quantity: foodEntry.quantity,
       measurement: foodEntry.measurement,
+      altServings: foodEntry.altServings,
     };
 
     await this.DB.putItem(data);

--- a/backend/tracker-diet/recentEntries/getRecentEntries.js
+++ b/backend/tracker-diet/recentEntries/getRecentEntries.js
@@ -35,7 +35,7 @@ class GetRecentEntries {
     var count = 0;
     var i;
     for (i = 0; i < entries.length && count < 10; i++) {
-      const key = entries[i].name;
+      const key = entries[i].foodItemID;
       if (!resultNames[key]) {
         resultNames[key] = 1;
         result.push(entries[i]);

--- a/mobile-app/src/api/diet/search/fatSecretAPI.js
+++ b/mobile-app/src/api/diet/search/fatSecretAPI.js
@@ -21,6 +21,8 @@ export async function searchFatSecret(searchInput, page = 0) {
   return convertResults(response?.data.foods_search.results.food);
 }
 
+export async function getByID() {}
+
 const convertResults = (results) => {
   var transformedResults = [];
 

--- a/mobile-app/src/api/diet/search/fatSecretAPI.js
+++ b/mobile-app/src/api/diet/search/fatSecretAPI.js
@@ -36,7 +36,7 @@ const convertResults = (results) => {
         carbCount: serving.carbohydrate,
         proteinCount: serving.protein,
         fatCount: serving.fat,
-        quantity: serving.number_of_units,
+        quantity: 1,
       };
       if (serving.is_default == "1") {
         defaultServing = entry;
@@ -45,7 +45,10 @@ const convertResults = (results) => {
     });
 
     transformedResults.push({
-      name: item.food_name,
+      name:
+        item.food_type == "Brand"
+          ? `${item.brand_name} ${item.food_name}`
+          : item.food_name,
       foodItemID: item.food_id,
       calorieCount: defaultServing.calorieCount,
       carbCount: defaultServing.carbCount,

--- a/mobile-app/src/api/diet/search/fatSecretAPI.js
+++ b/mobile-app/src/api/diet/search/fatSecretAPI.js
@@ -54,7 +54,7 @@ const convertResults = (results) => {
       proteinCount: defaultServing.proteinCount,
       measurement: defaultServing.measurement,
       quantity: defaultServing.quantity,
-      altServings: servings,
+      servingsDetails: servings,
     });
   });
 

--- a/mobile-app/src/api/diet/search/fatSecretAPI.js
+++ b/mobile-app/src/api/diet/search/fatSecretAPI.js
@@ -21,8 +21,6 @@ export async function searchFatSecret(searchInput, page = 0) {
   return convertResults(response?.data.foods_search.results.food);
 }
 
-export async function getByID() {}
-
 const convertResults = (results) => {
   var transformedResults = [];
 

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -281,7 +281,7 @@ export default function AddEntryModal({
             adjustsFontSizeToFit={true}
             numberOfLines={2}
           >
-            {foodEntry.name}{" "}
+            {foodEntry.name}
           </Text>
           <Spinner visible={isLoading}></Spinner>
           <View style={styles.serving}>

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -115,12 +115,28 @@ export default function AddEntryModal({
           return { label: item.measurement, value: index };
         });
 
-        setLabels(options);
-        setSelectedServing(options[0].value);
-        setBaseMacros(details[0]);
-        setQuantity(`${+details[0].quantity}`);
-        setServing(`${details[0].measurement}`);
-        setDetails(details);
+        //i dont know whether to set to previous entry's macros or to first serving option-
+        if (editing) {
+          setLabels(options);
+          setSelectedServing(
+            options.find((element) => element.label == foodEntry.measurement)
+              ?.value
+          );
+          setBaseMacros(foodEntry);
+          setQuantity(`${+foodEntry.quantity}`);
+          setServing(`${foodEntry.measurement}`);
+          setDetails(details);
+        } else {
+          var index = options.findIndex(
+            (element) => element.label == foodEntry.measurement
+          );
+          setLabels(options);
+          setSelectedServing(options[index].value);
+          setBaseMacros(details[index]);
+          setQuantity(`${+details[index].quantity}`);
+          setServing(`${details[index].measurement}`);
+          setDetails(details);
+        }
       },
       close() {
         setVisible(false);
@@ -147,6 +163,7 @@ export default function AddEntryModal({
         quantity: +quantity,
         measurement: serving,
         dateStamp: moment(day).format("YYYYMMDD"),
+        altServings: servingsDetails,
       };
       setIsLoading(true);
       token = await getAccessToken();
@@ -200,6 +217,7 @@ export default function AddEntryModal({
           carbCount: currentMacros.Carbs,
           quantity: +quantity,
           measurement: serving,
+          altServings: servingsDetails,
         };
         setIsLoading(true);
         token = await getAccessToken();

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -106,7 +106,7 @@ export default function AddEntryModal({
 
         //serving options related
         var details = [];
-        var options = foodEntry.altServings;
+        var options = foodEntry.servingsDetails;
         options = options.map((item, index) => {
           details.push(item);
           return { label: item.measurement, value: index };
@@ -159,7 +159,7 @@ export default function AddEntryModal({
         quantity: +quantity,
         measurement: serving,
         dateStamp: moment(day).format("YYYYMMDD"),
-        altServings: servingsDetails,
+        servingsDetails: servingsDetails,
       };
       setIsLoading(true);
       token = await getAccessToken();
@@ -221,7 +221,7 @@ export default function AddEntryModal({
         var updatedMeal = { ...meal };
         updatedEntry.SK = foodEntry.SK;
         updatedEntry.PK = foodEntry.PK;
-        updatedEntry.altServings = servingsDetails;
+        updatedEntry.servingsDetails = servingsDetails;
 
         var index = updatedMeal.entries.indexOf(foodEntry);
         updatedMeal.entries[index] = updatedEntry;

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -78,7 +78,6 @@ export default function AddEntryModal({
     carbCount: 0,
     fatCount: 0,
     measurement: "cup",
-    name: "",
     proteinCount: 0,
     quantity: 1,
   });
@@ -107,14 +106,12 @@ export default function AddEntryModal({
 
         //serving options related
         var details = [];
-        var options =
-          foodEntry?.altServings == null ? [foodEntry] : foodEntry.altServings;
+        var options = foodEntry.altServings;
         options = options.map((item, index) => {
           details.push(item);
           return { label: item.measurement, value: index };
         });
 
-        //i dont know whether to set to previous entry's macros or to first serving option-
         if (editing) {
           setLabels(options);
           setSelectedServing(
@@ -216,7 +213,6 @@ export default function AddEntryModal({
           carbCount: currentMacros.Carbs,
           quantity: +quantity,
           measurement: serving,
-          altServings: servingsDetails,
         };
         setIsLoading(true);
         token = await getAccessToken();
@@ -225,6 +221,7 @@ export default function AddEntryModal({
         var updatedMeal = { ...meal };
         updatedEntry.SK = foodEntry.SK;
         updatedEntry.PK = foodEntry.PK;
+        updatedEntry.altServings = servingsDetails;
 
         var index = updatedMeal.entries.indexOf(foodEntry);
         updatedMeal.entries[index] = updatedEntry;

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -77,7 +77,6 @@ export default function AddEntryModal({
     calorieCount: 0,
     carbCount: 0,
     fatCount: 0,
-    meal: "dinner",
     measurement: "cup",
     name: "",
     proteinCount: 0,
@@ -207,7 +206,7 @@ export default function AddEntryModal({
 
   const editEntry = async () => {
     try {
-      if (foodEntry.quantity != quantity) {
+      if (foodEntry.measurement != serving || foodEntry.quantity != quantity) {
         var updatedEntry = {
           name: foodEntry.name,
           calorieCount: currentMacros.Calories,

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -224,7 +224,13 @@ export default function AddEntryModal({
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <View style={styles.container}>
-          <Text style={styles.titleText}>{foodEntry.name} </Text>
+          <Text
+            style={styles.titleText}
+            adjustsFontSizeToFit={true}
+            numberOfLines={2}
+          >
+            {foodEntry.name}{" "}
+          </Text>
           <Spinner visible={isLoading}></Spinner>
           <View style={styles.serving}>
             <View style={styles.row}>


### PR DESCRIPTION
Changes made: stored alternate servings in the database.

**important: all developers must delete all of their previous food entries before merging in this change.**

Front End:
- Made it so that the font size for the titles are dynamic (if it is longer than 2 lines the font size will decrease so that it can fit on 2 lines)
- updated the default values when the modal is in "edit" mode so that it displays the macros of entry instead of the default option
- updated the default values when the modal is in "add" mode so that it opens to the serving option that was previously used, but uses the default serving values (quantity is set to 1)
- updated the condition needed to actually save when editing - previously it only checked for quantity but now it also checks for the serving option.

API/Back End:
- updated the default quantity that is returned from fat secret to always be 1
- updated the food item's name to also include the brand 
- updated the createFoodEntry query to include the serving options


video showing something:
https://github.com/user-attachments/assets/390b142e-23cd-44a8-a562-ca814e7967c9

screenshot of how it looks with a long title:
![IMG_8650](https://github.com/user-attachments/assets/fc567d0e-0a34-4914-b6bf-27baef05fbc3)


