### PR TITLE
Resolving bugs found during testing

### DIFF
--- a/mobile-app/src/api/diet/OFF/offAPI.js
+++ b/mobile-app/src/api/diet/OFF/offAPI.js
@@ -31,6 +31,12 @@ const convertResults = (response) => {
       nutriments?.proteins_serving ?? nutriments?.proteins_value ?? "0",
     measurement: response.product?.serving_size ?? "per serving",
   };
+
+  serving.calorieCount = serving.calorieCount.toFixed(2);
+  serving.carbCount = serving.carbCount.toFixed(2);
+  serving.fatCount = serving.fatCount.toFixed(2);
+  serving.proteinCount = serving.proteinCount.toFixed(2);
+
   var brandName = response.product?.brands ?? "";
   var name =
     response.product?.product_name_en ?? response.product?.product_name;

--- a/mobile-app/src/api/diet/fatSecret/fatSecretAPI.js
+++ b/mobile-app/src/api/diet/fatSecret/fatSecretAPI.js
@@ -56,44 +56,45 @@ export async function searchFatSecret(searchInput, page = 0) {
     region: "US",
   };
   const response = await axios.get(API, { headers: headers, params: params });
-  return convertResults(response?.data.foods_search.results.food);
+  return convertResults(response?.data.foods_search.results?.food);
 }
 
 const convertResults = (results) => {
   var transformedResults = [];
+  if (results != null) {
+    results.forEach((item) => {
+      var defaultServing;
+      var servings = item.servings.serving.map((serving) => {
+        var entry = {
+          servingID: serving.serving_id,
+          measurement: serving.serving_description,
+          calorieCount: serving.calories,
+          carbCount: serving.carbohydrate,
+          proteinCount: serving.protein,
+          fatCount: serving.fat,
+        };
+        if (serving.is_default == "1") {
+          defaultServing = entry;
+        }
+        return entry;
+      });
 
-  results.forEach((item) => {
-    var defaultServing;
-    var servings = item.servings.serving.map((serving) => {
-      var entry = {
-        servingID: serving.serving_id,
-        measurement: serving.serving_description,
-        calorieCount: serving.calories,
-        carbCount: serving.carbohydrate,
-        proteinCount: serving.protein,
-        fatCount: serving.fat,
-      };
-      if (serving.is_default == "1") {
-        defaultServing = entry;
-      }
-      return entry;
+      transformedResults.push({
+        name:
+          item.food_type == "Brand"
+            ? `${item.brand_name} ${item.food_name}`
+            : item.food_name,
+        foodItemID: item.food_id,
+        calorieCount: defaultServing.calorieCount,
+        carbCount: defaultServing.carbCount,
+        fatCount: defaultServing.fatCount,
+        proteinCount: defaultServing.proteinCount,
+        measurement: defaultServing.measurement,
+        quantity: "1",
+        servingsDetails: servings,
+      });
     });
-
-    transformedResults.push({
-      name:
-        item.food_type == "Brand"
-          ? `${item.brand_name} ${item.food_name}`
-          : item.food_name,
-      foodItemID: item.food_id,
-      calorieCount: defaultServing.calorieCount,
-      carbCount: defaultServing.carbCount,
-      fatCount: defaultServing.fatCount,
-      proteinCount: defaultServing.proteinCount,
-      measurement: defaultServing.measurement,
-      quantity: "1",
-      servingsDetails: servings,
-    });
-  });
+  }
 
   return transformedResults;
 };

--- a/mobile-app/src/api/diet/foodEntriesAPI.js
+++ b/mobile-app/src/api/diet/foodEntriesAPI.js
@@ -30,7 +30,8 @@ class FoodEntriesAPI {
       Authorization: `Bearer ${token}`,
     };
 
-    await axios.post(API, foodEntry, { headers: headers });
+    response = await axios.post(API, foodEntry, { headers: headers });
+    return response?.data;
   }
 
   static async updateFoodEntry(token, foodEntryID, foodEntry) {

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -203,7 +203,11 @@ const FitnessDiet = ({ navigation, route }) => {
         meal
       );
 
-      mealSetters[meal](result[meal]);
+      if (meal in result) {
+        mealSetters[meal](result[meal]);
+      } else {
+        mealSetters[meal](defaultMacros);
+      }
       setIsLoading(false);
     } catch (e) {
       errorResponse(e);

--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -241,14 +241,9 @@ const FitnessDiet = ({ navigation, route }) => {
       token = await getAccessToken();
       goals = await DietGoalsAPI.getDietGoals(token);
 
-      len = Object.keys(goals).length;
-
-      if (len == 0) {
-        console.log("this person has not set up goals");
-      } else {
+      if (goals != null) {
         setDietGoals(goals);
       }
-
       setIsLoading(false);
     } catch (e) {
       errorResponse(e);

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/MealPage.js
@@ -140,12 +140,12 @@ const MealPage = ({ navigation, route }) => {
       <View style={styles.topArea}>
         <TouchableOpacity
           onPress={() => {
-            var params = {
-              foodItemsChanged: foodEntriesChangedRef.current,
-            };
+            var params = {};
 
             if (refreshMeal != null) {
               params["refreshMeal"] = refreshMeal;
+            } else {
+              params["foodItemsChanged"] = foodEntriesChangedRef.current;
             }
             navigationService.navigate("fitness-diet", params);
           }}

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -193,7 +193,7 @@ const SearchFood = ({ navigation, route }) => {
           </TouchableOpacity>
         </View>
 
-        {searchResults.length > 1 ? (
+        {searchResults.length >= 1 ? (
           <ScrollView
             showsVerticalScrollIndicator={false}
             contentContainerStyle={styles.scrollContainer}

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -35,6 +35,7 @@ const SearchFood = ({ navigation, route }) => {
   });
   const [searchInput, setSearchInput] = useState("");
   const [searchResults, setResults] = useState([]);
+  const [text, setText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
   const addEntryRef = useRef(null);
@@ -106,6 +107,9 @@ const SearchFood = ({ navigation, route }) => {
       setIsLoading(true);
       foodItems = await RecentFoodEntriesAPI.getRecentFoodEntries(token);
       setResults(foodItems);
+      if (foodItems.length == 0) {
+        setText("Your recent foods will be shown here");
+      }
       setIsLoading(false);
     } catch (e) {
       errorResponse(e);
@@ -126,6 +130,7 @@ const SearchFood = ({ navigation, route }) => {
           duration: Toast.durations.LONG,
           position: Toast.positions.CENTER,
         });
+        setText("There are no results. Please enter something else");
       }
     } catch (e) {
       errorResponse(e);
@@ -196,34 +201,40 @@ const SearchFood = ({ navigation, route }) => {
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.scrollContainer}
         >
-          {searchResults.map((item, index) => (
-            <View key={index} style={styles.resultContainer}>
-              <View style={{ flexDirection: "vertical", flex: 1 }}>
-                <Text
-                  style={[
-                    styles.textStyle,
-                    { flexShrink: 1, flexWrap: "wrap" },
-                  ]}
-                >
-                  {item.name}
-                </Text>
-                <Text style={[styles.textStyle, { fontSize: 12 }]}>
-                  {item.calorieCount} cals
-                </Text>
-              </View>
+          {searchResults.length > 1 ? (
+            searchResults.map((item, index) => (
+              <View key={index} style={styles.resultContainer}>
+                <View style={{ flexDirection: "vertical", flex: 1 }}>
+                  <Text
+                    style={[
+                      styles.textStyle,
+                      { flexShrink: 1, flexWrap: "wrap" },
+                    ]}
+                  >
+                    {item.name}
+                  </Text>
+                  <Text style={[styles.textStyle, { fontSize: 12 }]}>
+                    {item.calorieCount} cals
+                  </Text>
+                </View>
 
-              <TouchableOpacity
-                onPress={() => {
-                  addEntryRef.current.open(item);
-                }}
-              >
-                <Image
-                  style={styles.smallImage}
-                  source={require("../../../assets/images/plus512.png")}
-                />
-              </TouchableOpacity>
-            </View>
-          ))}
+                <TouchableOpacity
+                  onPress={() => {
+                    addEntryRef.current.open(item);
+                  }}
+                >
+                  <Image
+                    style={styles.smallImage}
+                    source={require("../../../assets/images/plus512.png")}
+                  />
+                </TouchableOpacity>
+              </View>
+            ))
+          ) : (
+            <Text style={[styles.textStyle, { textAlign: "center" }]}>
+              {text}
+            </Text>
+          )}
         </ScrollView>
         <AddEntryModal
           getRef={(ref) => (addEntryRef.current = ref)}

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -125,12 +125,7 @@ const SearchFood = ({ navigation, route }) => {
       setIsLoading(false);
 
       if (response.length == 0) {
-        Toast.show("Sorry that item isn't available.", {
-          ...styles.errorToast,
-          duration: Toast.durations.LONG,
-          position: Toast.positions.CENTER,
-        });
-        setText("There are no results. Please enter something else");
+        setText("Sorry that item isnt available.");
       }
     } catch (e) {
       errorResponse(e);
@@ -197,12 +192,13 @@ const SearchFood = ({ navigation, route }) => {
             />
           </TouchableOpacity>
         </View>
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={styles.scrollContainer}
-        >
-          {searchResults.length > 1 ? (
-            searchResults.map((item, index) => (
+
+        {searchResults.length > 1 ? (
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.scrollContainer}
+          >
+            {searchResults.map((item, index) => (
               <View key={index} style={styles.resultContainer}>
                 <View style={{ flexDirection: "vertical", flex: 1 }}>
                   <Text
@@ -229,13 +225,14 @@ const SearchFood = ({ navigation, route }) => {
                   />
                 </TouchableOpacity>
               </View>
-            ))
-          ) : (
-            <Text style={[styles.textStyle, { textAlign: "center" }]}>
-              {text}
-            </Text>
-          )}
-        </ScrollView>
+            ))}
+          </ScrollView>
+        ) : (
+          <View style={styles.textContainer}>
+            <Text style={styles.greyText}>{text}</Text>
+          </View>
+        )}
+
         <AddEntryModal
           getRef={(ref) => (addEntryRef.current = ref)}
           mealName={mealName}
@@ -317,6 +314,19 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: ValueSheet.fonts.primaryFont,
     color: ValueSheet.colours.primaryColour,
+  },
+  greyText: {
+    fontSize: 20,
+    fontFamily: ValueSheet.fonts.primaryFont,
+    color: ValueSheet.colours.inputGrey,
+    textAlign: "center",
+    alignSelf: "center",
+  },
+  textContainer: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+    marginBottom: 150,
   },
   backArrow: {
     height: 35,

--- a/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
+++ b/mobile-app/src/screens/Fitness-Diet/mealPages/SearchFood.js
@@ -119,6 +119,14 @@ const SearchFood = ({ navigation, route }) => {
       response = await searchFatSecret(input);
       setResults(response);
       setIsLoading(false);
+
+      if (response.length == 0) {
+        Toast.show("Sorry that item isn't available.", {
+          ...styles.errorToast,
+          duration: Toast.durations.LONG,
+          position: Toast.positions.CENTER,
+        });
+      }
     } catch (e) {
       errorResponse(e);
     }

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -19,9 +19,7 @@ import DropDownPicker from "react-native-dropdown-picker";
 import { ValueSheet } from "../../../ValueSheet";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
 import FoodEntriesMacrosAPI from "../../../api/diet/foodEntriesMacrosAPI";
-
-//TO DOs:
-//1. maybe: make a call to the api to get further details like serving options (?) - will need to decide later as we integrate with our selected third party database
+import Toast from "react-native-root-toast";
 
 const macroTitles = [
   {
@@ -269,18 +267,29 @@ export default function AddEntryModal({
   };
 
   const recalMacrosByQuantity = () => {
-    var newMacros = {
-      calorieCount: +((macros.calorieCount / prevQuantity) * quantity).toFixed(
-        2
-      ),
-      carbCount: +((macros.carbCount / prevQuantity) * quantity).toFixed(2),
-      fatCount: +((macros.fatCount / prevQuantity) * quantity).toFixed(2),
-      proteinCount: +((macros.proteinCount / prevQuantity) * quantity).toFixed(
-        2
-      ),
-    };
-    setMacros(newMacros);
-    setPrevQuantity(quantity);
+    if (!isNaN(Number(quantity)) && Number(quantity) > 0) {
+      var newMacros = {
+        calorieCount: +(
+          (macros.calorieCount / prevQuantity) *
+          quantity
+        ).toFixed(2),
+        carbCount: +((macros.carbCount / prevQuantity) * quantity).toFixed(2),
+        fatCount: +((macros.fatCount / prevQuantity) * quantity).toFixed(2),
+        proteinCount: +(
+          (macros.proteinCount / prevQuantity) *
+          quantity
+        ).toFixed(2),
+      };
+      setMacros(newMacros);
+      setPrevQuantity(quantity);
+    } else {
+      setQuantity(prevQuantity);
+      Toast.show("Please enter a valid number greater than 0", {
+        ...styles.errorToast,
+        duration: Toast.durations.LONG,
+        position: Toast.positions.BOTTOM,
+      });
+    }
   };
 
   return (

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -137,6 +137,10 @@ export default function AddEntryModal({
     getRef(ref);
   }, []);
 
+  const add2Decimals = (num1, num2) => {
+    return (num1 * 100 + num2 * 100) / 100;
+  };
+
   const onAddFoodEntry = async () => {
     try {
       var newFoodEntry = {
@@ -154,7 +158,8 @@ export default function AddEntryModal({
       };
       setIsLoading(true);
       token = await getAccessToken();
-      await FoodEntriesAPI.createFoodEntry(token, newFoodEntry);
+      response = await FoodEntriesAPI.createFoodEntry(token, newFoodEntry);
+      console.log(response); // this should include the sk
       newMeal = await FoodEntriesMacrosAPI.getFoodMacrosForMeal(
         token,
         moment(day).format("YYYYMMDD"),
@@ -268,6 +273,7 @@ export default function AddEntryModal({
 
   const recalMacrosByQuantity = () => {
     if (!isNaN(Number(quantity)) && Number(quantity) > 0) {
+      var roundedQuantity = quantity.toFixed(2);
       var newMacros = {
         calorieCount: +(
           (macros.calorieCount / prevQuantity) *
@@ -281,7 +287,8 @@ export default function AddEntryModal({
         ).toFixed(2),
       };
       setMacros(newMacros);
-      setPrevQuantity(quantity);
+      setQuantity(roundedQuantity);
+      setPrevQuantity(roundedQuantity);
     } else {
       setQuantity(prevQuantity);
       Toast.show("Please enter a valid number greater than 0", {

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -18,7 +18,6 @@ import Spinner from "react-native-loading-spinner-overlay";
 import DropDownPicker from "react-native-dropdown-picker";
 import { ValueSheet } from "../../../ValueSheet";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
-import FoodEntriesMacrosAPI from "../../../api/diet/foodEntriesMacrosAPI";
 import Toast from "react-native-root-toast";
 
 const macroTitles = [

--- a/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
+++ b/mobile-app/src/screens/Fitness-Diet/modals/AddEntryModal.js
@@ -18,6 +18,7 @@ import Spinner from "react-native-loading-spinner-overlay";
 import DropDownPicker from "react-native-dropdown-picker";
 import { ValueSheet } from "../../../ValueSheet";
 import UpdateMacrosModal from "../../Setup/Diet/UpdateMacrosModal";
+import FoodEntriesMacrosAPI from "../../../api/diet/foodEntriesMacrosAPI";
 
 //TO DOs:
 //1. maybe: make a call to the api to get further details like serving options (?) - will need to decide later as we integrate with our selected third party database
@@ -138,10 +139,6 @@ export default function AddEntryModal({
     getRef(ref);
   }, []);
 
-  const add2Decimals = (num1, num2) => {
-    return (num1 * 100 + num2 * 100) / 100;
-  };
-
   const onAddFoodEntry = async () => {
     try {
       var newFoodEntry = {
@@ -160,6 +157,12 @@ export default function AddEntryModal({
       setIsLoading(true);
       token = await getAccessToken();
       await FoodEntriesAPI.createFoodEntry(token, newFoodEntry);
+      newMeal = await FoodEntriesMacrosAPI.getFoodMacrosForMeal(
+        token,
+        moment(day).format("YYYYMMDD"),
+        newFoodEntry.meal
+      );
+      newMeal = newMeal[newFoodEntry.meal];
 
       setIsLoading(false);
       setVisible(false);
@@ -169,21 +172,9 @@ export default function AddEntryModal({
       };
 
       if (prevPage == "mealPage") {
-        meal.calorieCount = add2Decimals(
-          meal.calorieCount,
-          newFoodEntry.calorieCount
-        );
-        meal.proteinCount = add2Decimals(
-          meal.proteinCount,
-          newFoodEntry.proteinCount
-        );
-        meal.carbCount = add2Decimals(meal.carbCount, newFoodEntry.carbCount);
-        meal.fatCount = add2Decimals(meal.fatCount, newFoodEntry.fatCount);
-        meal.entries.push(newFoodEntry);
-
         params["dateString"] = day.toLocaleDateString();
         params["mealName"] = mealName;
-        params["meal"] = meal;
+        params["meal"] = newMeal;
       }
 
       navigationService.navigate(prevPage, params);


### PR DESCRIPTION
Resolving the following bugs:

1. [Prevent error toast from appearing when there are no search results](https://github.com/oasis-alltracker/all-tracker/issues/143). 

The issue: In `FatSecretAPI.js` the input into the function `convertResults` assumed `results.foods` was not null, but when there are no search results fat secret returns an empty results item. 

The solution: I changed it so that the input is `results?.foods`. I also modified convert results to return an empty array when the input is null so it maps as expected. I also added some logic so that it can display some text when there are no search results so that the user can know their request went through. 

Video of how it appears with no entries and with no search results:

https://github.com/user-attachments/assets/978f4c42-92bb-4573-93a5-214c87f96315

Screenshot of how the recent entries appears:
<img width="295" height="639" alt="IMG_8803" src="https://github.com/user-attachments/assets/ee4532af-3b1e-4fc6-a7bd-b458ff868702" />


2. [Odd behaviour when editing and deleting a newly created entry.](https://github.com/oasis-alltracker/all-tracker/issues/142). 

The issue: The entry shown when returning to the meal page after creating a new food entry does not contain the entry id (aka the SK). So while it appears to the user that they could edit this new entry, the database could not identify which entry to edit and would instead make a new entry that has no sort key. This made it such that it wasn't associated with a meal or date but would always appear as the most recently added entry. When trying to open this entry the app would then crash. 

The solution: We updated the back end to return the entry's ID and added it to the entry shown on the meal page. This is seen on lines 163,170, and 171 in `AddEntryModal.js`.

Video:

https://github.com/user-attachments/assets/58f12210-6d37-4ed7-94f9-96185d502df8



3. [Quantity wouldnt calculate properly when a comma was inputted.](https://github.com/oasis-alltracker/all-tracker/issues/142). 

The issue: As I developed on iOS I wasnt aware the android decimal pad included commas. There was no validation done to ensure the input into the quantity text input was a proper number that was greater than 0. 

The solution: Added validation to the `recalMacrosByQuantity` function in `AddEntryModal`. If the validation fails it will reset the value to be what was the most recent valid quantity. This may need additional checks such as restricting decimal length but as of right now it checks for a valid number and that the quantity is greater than 0. Should be discussed as a team. The changes can be seen on lines 285 and 300-306. **As there is a toast shown when it is not valid this will need further work in a future PR where we discuss how to address showing error messages in modals as toasts do not appear as expected.**

**Has been validated to work on Android**

4. [Prevent error toast that appears when diet goals is not set up.](https://github.com/oasis-alltracker/all-tracker/issues/141). 

The issue: The diet goals was expecting the unset diet goals to return as an empty json `{}`, but it returned a null value. 

The solution: Changed the logic to expect a null value in the response data to indicate that the diet goals was not set up. 