### PR TITLE
Fixed "not very active" selection bug

### DIFF
--- a/mobile-app/src/screens/Setup/Diet/Step7.js
+++ b/mobile-app/src/screens/Setup/Diet/Step7.js
@@ -29,7 +29,7 @@ const DietStep7 = (props) => {
   };
 
   const onNext = () => {
-    if (activityLevel) {
+    if (activityLevel != null) {
       if (goal === "maintain") {
         const weightChangePerWeek = 0;
         navigationService.navigate("dietStep9", {


### PR DESCRIPTION
In the diet goal setup step for selecting your physical activity level (`/screens/Setup/Diet/Step7.js`), the "not very active" option could be selected but not proceeded with when pressing the "next" button - while the other activity options worked fine. This resulted in a toast message asking you to make a selection, even though you did.

Behaviour before the fix with the "maintain weight" goal: 

https://github.com/user-attachments/assets/8f14c0b6-ce1e-497f-8070-223dc87ab550

**The issue**: the `onNext` function checks for the value of the activityLevel state variable, which is either null (initial value) or a number from 0 to 3 for each index of the activity levels. When one is selected, the activityLevel state variable is updated to that index value, and then `onNext` checks for the value of it to proceed. 
The intent is for the page to prevent proceeding to the next step when activityLevel == null and proceed when activityLevel != null. The issue arises because the "not very active" option is the first (index = 0) option, meaning the if statement evaluates to activityLevel = 0. Javascript sees both null and 0 as corresponding to false for an if check like `if (activityLevel) {...}` and prevents using this option to proceed. 

**The fix**: updating the if condition from just `if (activityLevel) { //proceed }` to `if (activityLevel != null) { //proceed }` to allow for the index of 0 to let you proceed to the next step. 

Behaviour after the fix, with the "maintain weight" goal: 

https://github.com/user-attachments/assets/bc260230-00c0-4168-997d-1e557b714dec