### PR TITLE
Updated diet goals setup to only update goals on "save"/"next" press

### DIFF
--- a/mobile-app/src/screens/Setup/Diet/Step9.js
+++ b/mobile-app/src/screens/Setup/Diet/Step9.js
@@ -101,7 +101,17 @@ const DietStep9 = (props) => {
     }
   };
 
-  const onNext = () => {
+  const onNext = async () => {
+    const token = await getAccessToken();
+    DietGoalsAPI.updateDietGoals(token, {
+      carbGoal: carbGoalValue,
+      proteinGoal: proteinGoalValue,
+      fatGoal: fatGoalValue,
+      calorieGoal: {
+        value: calorieGoalValue,
+        units: calorieUnit,
+      },
+    });
     if (isEditingMacros) {
       navigationService.navigate("fitness-diet", {
         isEditingGoals: isEditingMacros,
@@ -163,20 +173,10 @@ const DietStep9 = (props) => {
           text: "Fats:",
         },
       ]);
-      const token = await getAccessToken();
       setCalorieGoalValue(Math.round(dailyCalorieIntake));
       setCarbGoalValue(Math.round(carbs));
       setProteinGoalValue(Math.round(protein));
       setFatGoalValue(Math.round(fat));
-      DietGoalsAPI.updateDietGoals(token, {
-        carbGoal: Math.round(carbs),
-        proteinGoal: Math.round(protein),
-        fatGoal: Math.round(fat),
-        calorieGoal: {
-          value: Math.round(dailyCalorieIntake),
-          units: calorieUnit,
-        },
-      });
       setIsLoading(false);
     };
 

--- a/mobile-app/src/screens/Setup/Diet/Step9.js
+++ b/mobile-app/src/screens/Setup/Diet/Step9.js
@@ -33,11 +33,12 @@ const DietStep9 = (props) => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [calories, setCalories] = useState(0);
-  const [calorieGoalValue, setCalorieGoalValue] = useState(0);
+  const [calorieUnit, setCalorieUnit] = useState("kcal");
+  const [calorieGoalValue, setCalorieGoalValue] = useState(0); //holds calorie value and unit
   const [carbGoalValue, setCarbGoalValue] = useState(0);
   const [proteinGoalValue, setProteinGoalValue] = useState(0);
   const [fatGoalValue, setFatGoalValue] = useState(0);
-  const [calorieUnit, setCalorieUnit] = useState("kcal");
+
   const [datas, setDatas] = useState([
     {
       title: "0 g",
@@ -91,13 +92,6 @@ const DietStep9 = (props) => {
         return item;
       });
       setDatas(newDatas);
-      const token = await getAccessToken();
-      DietGoalsAPI.updateDietGoals(token, {
-        carbGoal: newCarbs,
-        proteinGoal: newProteins,
-        fatGoal: newFats,
-        calorieGoal: newCalories,
-      });
     }
   };
 
@@ -107,10 +101,7 @@ const DietStep9 = (props) => {
       carbGoal: carbGoalValue,
       proteinGoal: proteinGoalValue,
       fatGoal: fatGoalValue,
-      calorieGoal: {
-        value: calorieGoalValue,
-        units: calorieUnit,
-      },
+      calorieGoal: calorieGoalValue,
     });
   };
 
@@ -177,7 +168,10 @@ const DietStep9 = (props) => {
           text: "Fats:",
         },
       ]);
-      setCalorieGoalValue(Math.round(dailyCalorieIntake));
+      setCalorieGoalValue({
+        value: Math.round(dailyCalorieIntake),
+        units: calorieUnit,
+      });
       setCarbGoalValue(Math.round(carbs));
       setProteinGoalValue(Math.round(protein));
       setFatGoalValue(Math.round(fat));

--- a/mobile-app/src/screens/Setup/Diet/Step9.js
+++ b/mobile-app/src/screens/Setup/Diet/Step9.js
@@ -101,7 +101,7 @@ const DietStep9 = (props) => {
     }
   };
 
-  const onNext = async () => {
+  const updateGoals = async () => {
     const token = await getAccessToken();
     DietGoalsAPI.updateDietGoals(token, {
       carbGoal: carbGoalValue,
@@ -112,6 +112,10 @@ const DietStep9 = (props) => {
         units: calorieUnit,
       },
     });
+  };
+
+  const onNext = async () => {
+    updateGoals();
     if (isEditingMacros) {
       navigationService.navigate("fitness-diet", {
         isEditingGoals: isEditingMacros,


### PR DESCRIPTION
When going through the diet goals setup steps (whether through the edit macro goals modal or through the general setup flow), near the end you reach the goals summary page. If you reach this and then use the back buttons to exit the setup flow, the goals you saw in the summary will still be saved and appear in the diet tab, even though you never selected "save" or proceeded to finish the setup flow. 

This was caused by a call to update the diet goals in the backend in the useEffect immediately after the calculation of the goals based on the prior steps. 

**The solution**: move the API call to update the goals to the onNext function (triggered when the next/save button is pressed). This still lets the goals be calculated and updated visually and in state variables in the useEffect, but the goals will not update in the backend until next/save is pressed. If you exit through the back buttons, the diet page will not reflect any goal updates from the setup flow. 

Screen recording of behaviour: 

https://github.com/user-attachments/assets/be4ff57c-6306-4eca-bd39-481c018f0f25
