### PR TITLE
resolving error that occurs when the diet goals setup is not completed

### DIFF
--- a/mobile-app/src/screens/Fitness-Diet/index.js
+++ b/mobile-app/src/screens/Fitness-Diet/index.js
@@ -241,11 +241,7 @@ const FitnessDiet = ({ navigation, route }) => {
       token = await getAccessToken();
       goals = await DietGoalsAPI.getDietGoals(token);
 
-      len = Object.keys(goals).length;
-
-      if (len == 0) {
-        console.log("this person has not set up goals");
-      } else {
+      if (goals != null) {
         setDietGoals(goals);
       }
 


### PR DESCRIPTION
Resolves [this issue](https://github.com/oasis-alltracker/all-tracker/issues/141). 

The issue: The diet goals was expecting the diet goals api to return as an empty json `{}` when the setup was not complete, but it returned a null value. 

The solution: Changed the logic to expect a null value in the response data to indicate that the diet goals was not set up. 