### PR TITLE
Fixing error that appears when opening Stats details 

### DIFF
--- a/mobile-app/src/screens/Mood-Sleep/Statistics.js
+++ b/mobile-app/src/screens/Mood-Sleep/Statistics.js
@@ -12,7 +12,7 @@ import MoodStats from "../Stats/MoodStats";
 import SleepStats from "../Stats/SleepStats";
 import { sharedStyles } from "../styles";
 import { ValueSheet } from "../../ValueSheet";
-import { InAppReview } from "react-native-in-app-review";
+import InAppReview from "react-native-in-app-review";
 
 const Statistics = ({ trackingPreferences, updateStats }) => {
   var thisSunday = new Date();

--- a/mobile-app/src/screens/Todos-Habits/Statistics.js
+++ b/mobile-app/src/screens/Todos-Habits/Statistics.js
@@ -8,7 +8,7 @@ import {
   View,
 } from "react-native";
 import moment from "moment";
-import { InAppReview } from "react-native-in-app-review";
+import InAppReview from "react-native-in-app-review";
 import TaskStats from "../Stats/TaskStats";
 import HabitStats from "../Stats/HabitStats";
 import { sharedStyles } from "../styles";


### PR DESCRIPTION
Issue: Fixed https://github.com/oasis-alltracker/all-tracker/issues/160.
When scrolling to the stats page of to-dos/habits and of mind/sleep this error would appear: 
<img width="626" height="40" alt="image" src="https://github.com/user-attachments/assets/448130dc-a809-4698-92af-c9ed8f707746" />

This was caused by an improper import that would ask the user for an app review when opening the stats page. 

Solution: fixed the import statement in each file.


https://github.com/user-attachments/assets/1511d3d4-a04b-42a8-a8c1-22e905e9311d

