### PR TITLE
delete the users diet goals when their account is deleted

### DIFF
--- a/backend/userInfo/user/deleteUser.js
+++ b/backend/userInfo/user/deleteUser.js
@@ -71,6 +71,9 @@ class DeleteUser {
 
     const toDos = await this.getAll(email, "toDo");
     await this.DB.deleteItems(`${email}-toDo`, toDos);
+
+    const dietGoals = await this.getAll(email, "dietGoals");
+    await this.DB.deleteItems(`${email}-dietGoals`, dietGoals);
   }
 
   async getAll(user, pkSuffix) {


### PR DESCRIPTION
Updated back end's delete user endpoint to delete the users diet goals when the users account is deleted. Tested via rest.http and by deleting my user through the app and inspecting the dynamodb table. 