### PR TITLE
Resolved minor issue resulting from diet steps back button bugfix

### DIFF
--- a/mobile-app/src/screens/Setup/Diet/CurrentWeight.js
+++ b/mobile-app/src/screens/Setup/Diet/CurrentWeight.js
@@ -25,7 +25,7 @@ const CurrentWeight = (props) => {
     if (weight) {
       if (!isNaN(Number(weight))) {
         if (dietFactors.goal == "maintain") {
-          dietFactors.targetWeight = dietFactors.currentWeight;
+          dietFactors.targetWeight = { ...dietFactors.currentWeight };
           navigationService.navigate("heightInput", {
             selectedTrackers,
             isEditingMacros,


### PR DESCRIPTION
After PR #164 was merged into main, upon testing there was a small issue identified when following this flow: 
1. Select "maintain weight" as the goal and press "next"
2. Input current weight and press "next"
3. Input current height, but do not push "next"
4. Use "back" to return to current weight input, then to goal selection
5. Select the "gain weight" goal and press "next"
6. See that current weight is the same as previously inputted, press "next"
7. See that target weight is the same as current weight; change to a number greater than current weight and press "next"

This is where the issue arises - the user cannot proceed, and receives an error toast message telling them to provide a weight greater than their current weight. No matter how many times they do as the message says, they will be unable to proceed. 
This happens because when "maintain weight" is the selected goal, the target weight is updated to match the current weight, to facilitate calculations after the user goes through all necessary steps. However, the target weight was assigned to be the same as the current weight - meaning that when target weight was edited, so was current weight, making them equal rather than the target weight being greater. 

The solution was to simply assign a _copy_ of the current weight to target weight instead. Using the JavaScript spread operator (`...`) was sufficient in this case as a weight only includes fields for a value (weight) and units. 

Screen recording of behaviour before fix:

https://github.com/user-attachments/assets/e48eb63d-97f8-49ef-87ab-d9d3a9a25c49

Screen recording of behaviour after fix: 

https://github.com/user-attachments/assets/bcedb2b8-275e-4c8b-93f1-1fb08dda8924