### PR TITLE
Disable notifications toggles when system notifications is disabled 

### DIFF
--- a/mobile-app/src/api/notifications/notificationsHandler.js
+++ b/mobile-app/src/api/notifications/notificationsHandler.js
@@ -148,48 +148,50 @@ class NotificationsHandler {
     notifications,
     prevExpoIDs = false
   ) {
-    var expoIDs = [];
-    if (notifications) {
-      for (var trigger of triggers) {
-        if (Platform.OS === "android" && trigger.day) {
-          trigger = {
-            seconds: this.getSecondsUntilDate(trigger),
-            repeats: false,
-          };
-        }
-        try {
-          const expoID = await this.schedulePushNotification(
-            title,
-            body,
-            trigger
-          );
-          expoIDs.push(expoID);
-        } catch (e) {
-          console.log(e);
+    if (!notificationID.endsWith("Preference")) {
+      var expoIDs = [];
+      if (notifications) {
+        for (var trigger of triggers) {
+          if (Platform.OS === "android" && trigger.day) {
+            trigger = {
+              seconds: this.getSecondsUntilDate(trigger),
+              repeats: false,
+            };
+          }
+          try {
+            const expoID = await this.schedulePushNotification(
+              title,
+              body,
+              trigger
+            );
+            expoIDs.push(expoID);
+          } catch (e) {
+            console.log(e);
+          }
         }
       }
-    }
 
-    if (prevExpoIDs) {
-      for (var prevExpoID of prevExpoIDs) {
-        await this.cancelPushNotification(prevExpoID);
+      if (prevExpoIDs) {
+        for (var prevExpoID of prevExpoIDs) {
+          await this.cancelPushNotification(prevExpoID);
+        }
       }
-    }
 
-    try {
-      await this.updateNotification(
-        token,
-        notificationID,
-        expoIDs,
-        title,
-        body,
-        triggers,
-        "on"
-      );
-      return expoIDs;
-    } catch (e) {
-      console.log(e);
-      return false;
+      try {
+        await this.updateNotification(
+          token,
+          notificationID,
+          expoIDs,
+          title,
+          body,
+          triggers,
+          "on"
+        );
+        return expoIDs;
+      } catch (e) {
+        console.log(e);
+        return false;
+      }
     }
   }
   static async turnOffNotification(token, notificationID, expoIDs) {

--- a/mobile-app/src/screens/Auth/UnlockAccount.js
+++ b/mobile-app/src/screens/Auth/UnlockAccount.js
@@ -23,7 +23,7 @@ import {
 } from "react-native";
 import { Header, Button } from "../../components";
 import navigationService from "../../navigators/navigationService";
-import NotificationsHandler from "../../../api/notifications/notificationsHandler";
+import NotificationsHandler from "../../api/notifications/notificationsHandler";
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
 import { getUniqueId } from "react-native-device-info";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -118,7 +118,11 @@ const UnlockAccount = (props) => {
         "notifications"
       );
       if (allNotifications[0]?.preference === "on") {
-        await NotificationsHandler.checkNotificationsStatus(token);
+        systemNotificationsStatus =
+          await NotificationsHandler.checkNotificationsStatus(token);
+        if (systemNotificationsStatus) {
+          NotificationsHandler.turnOnAllNotifications(token);
+        }
       }
     } else {
       navigationService.navigate("contract");

--- a/mobile-app/src/screens/Auth/UnlockAccount.js
+++ b/mobile-app/src/screens/Auth/UnlockAccount.js
@@ -120,9 +120,7 @@ const UnlockAccount = (props) => {
       if (allNotifications[0]?.preference === "on") {
         systemNotificationsStatus =
           await NotificationsHandler.checkNotificationsStatus(token);
-        if (systemNotificationsStatus) {
-          NotificationsHandler.turnOnAllNotifications(token);
-        }
+        NotificationsHandler.turnOnAllNotifications(token);
       }
     } else {
       navigationService.navigate("contract");

--- a/mobile-app/src/screens/Auth/UnlockAccount.js
+++ b/mobile-app/src/screens/Auth/UnlockAccount.js
@@ -23,6 +23,7 @@ import {
 } from "react-native";
 import { Header, Button } from "../../components";
 import navigationService from "../../navigators/navigationService";
+import NotificationsHandler from "../../../api/notifications/notificationsHandler";
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
 import { getUniqueId } from "react-native-device-info";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -111,9 +112,16 @@ const UnlockAccount = (props) => {
 
     setIsLoading(false);
     if (userData.isSetupComplete) {
-      await navigationService.reset("main", 0);
+      navigationService.reset("main", 0);
+      var allNotifications = await NotificationsHandler.getNotifications(
+        token,
+        "notifications"
+      );
+      if (allNotifications[0]?.preference === "on") {
+        await NotificationsHandler.checkNotificationsStatus(token);
+      }
     } else {
-      await navigationService.navigate("contract");
+      navigationService.navigate("contract");
     }
   };
 

--- a/mobile-app/src/screens/Settings/Notifications/index.js
+++ b/mobile-app/src/screens/Settings/Notifications/index.js
@@ -58,7 +58,7 @@ const Notifications = () => {
     setIsLoading(true);
     const token = await getAccessToken();
 
-    if (isNotificationsEnabled) {
+    if (isNotificationsEnabled && isSystemNotificationsEnabled) {
       await NotificationsHandler.turnOffAllNotifications(token);
       setIsNotificationsEnabled(false);
       setIsHabitsEnabled(false);
@@ -73,9 +73,10 @@ const Notifications = () => {
       var systemNotificationsStatus = true;
       systemNotificationsStatus =
         await NotificationsHandler.checkNotificationsStatus(token);
+      setIsSystemNotificationsEnabled(systemNotificationsStatus ? true : false);
       if (systemNotificationsStatus) {
         await NotificationsHandler.turnOnAllNotifications(token);
-        setIsNotificationsEnabled((previousState) => !previousState);
+        setIsNotificationsEnabled(true);
       } else {
         Toast.show({
           type: "info",
@@ -631,7 +632,7 @@ const Notifications = () => {
           var newSleepNotifications =
             await NotificationsHandler.getNotifications(token, "sleep-");
 
-          setIsSystemNotificationsEnabled(systemNotifications);
+          setIsSystemNotificationsEnabled(systemNotifications ? true : false);
           setIsNotificationsEnabled(allNotifications[0]?.preference === "on");
           setIsHabitsEnabled(habitNotifications == "on");
           setIsTasksEnabled(taskNotificationsIsOn == "on");
@@ -746,7 +747,10 @@ const Notifications = () => {
                   width={55}
                   height={32}
                   onValueChange={habitsToggled}
-                  value={isHabitsEnabled && isSystemNotificationsEnabled}
+                  disabled={
+                    !isNotificationsEnabled || !isSystemNotificationsEnabled
+                  }
+                  value={isHabitsEnabled}
                   trackColor={{
                     true: ValueSheet.colours.secondaryColour,
                     false: ValueSheet.colours.purple,
@@ -766,7 +770,10 @@ const Notifications = () => {
                   width={55}
                   height={32}
                   onValueChange={tasksToggled}
-                  value={isTasksEnabled && isSystemNotificationsEnabled}
+                  disabled={
+                    !isNotificationsEnabled || !isSystemNotificationsEnabled
+                  }
+                  value={isTasksEnabled}
                   trackColor={{
                     true: ValueSheet.colours.secondaryColour,
                     false: ValueSheet.colours.purple,
@@ -794,11 +801,14 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={breakfastToggled}
-                    value={isBreakfastEnabled && isSystemNotificationsEnabled}
+                    value={isBreakfastEnabled}
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
                     }}
+                    disabled={
+                      !isNotificationsEnabled || !isSystemNotificationsEnabled
+                    }
                     thumbColor={
                       isBreakfastEnabled && isSystemNotificationsEnabled
                         ? ValueSheet.colours.secondaryColour
@@ -860,7 +870,10 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={lunchToggled}
-                    value={isLunchEnabled && isSystemNotificationsEnabled}
+                    value={isLunchEnabled}
+                    disabled={
+                      !isNotificationsEnabled || !isSystemNotificationsEnabled
+                    }
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
@@ -926,7 +939,10 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={dinnerToggled}
-                    value={isDinnerEnabled && isSystemNotificationsEnabled}
+                    disabled={
+                      !isNotificationsEnabled || !isSystemNotificationsEnabled
+                    }
+                    value={isDinnerEnabled}
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
@@ -1002,11 +1018,12 @@ const Notifications = () => {
                 title="Wellness check-in"
                 body="It's time to check in with yourself"
                 notifications={moodNotifications}
-                isToggled={
-                  isWellnessCheckinToggled && isSystemNotificationsEnabled
-                }
+                isToggled={isWellnessCheckinToggled}
                 toggledHandler={wellnessCheckinToggled}
                 setIsToggled={setIsWellnessCheckinToggled}
+                disabled={
+                  !isNotificationsEnabled || !isSystemNotificationsEnabled
+                }
                 group="mood"
               />
             )}
@@ -1016,11 +1033,12 @@ const Notifications = () => {
                   title="Sleep review"
                   body="Time to wake up amd review your sleep"
                   notifications={morningNotifications}
-                  isToggled={
-                    isMorningAlarmToggled && isSystemNotificationsEnabled
-                  }
+                  isToggled={isMorningAlarmToggled}
                   toggledHandler={morningAlarmToggled}
                   setIsToggled={setIsMorningAlarmToggled}
+                  disabled={
+                    !isNotificationsEnabled || !isSystemNotificationsEnabled
+                  }
                   group="morning"
                 />
               </>

--- a/mobile-app/src/screens/Settings/Notifications/index.js
+++ b/mobile-app/src/screens/Settings/Notifications/index.js
@@ -47,6 +47,8 @@ const Notifications = () => {
   const [moodNotifications, setMoodNotifications] = useState(false);
 
   const [isMorningAlarmToggled, setIsMorningAlarmToggled] = useState(false);
+  const [isSystemNotificationsEnabled, setIsSystemNotificationsEnabled] =
+    useState(false);
   const [morningNotifications, setMorningNotifications] = useState(false);
   const [isBedTimeReminderToggled, setIsBedTimeReminderToggled] =
     useState(false);
@@ -590,6 +592,9 @@ const Notifications = () => {
             "notifications"
           );
 
+          var systemNotifications =
+            await NotificationsHandler.checkNotificationsStatus(token);
+
           var habitNotifications =
             await NotificationsHandler.getGroupPreferenceNotificationsState(
               token,
@@ -626,6 +631,7 @@ const Notifications = () => {
           var newSleepNotifications =
             await NotificationsHandler.getNotifications(token, "sleep-");
 
+          setIsSystemNotificationsEnabled(systemNotifications);
           setIsNotificationsEnabled(allNotifications[0]?.preference === "on");
           setIsHabitsEnabled(habitNotifications == "on");
           setIsTasksEnabled(taskNotificationsIsOn == "on");
@@ -716,13 +722,13 @@ const Notifications = () => {
             width={55}
             height={32}
             onValueChange={allNotificationsToggled}
-            value={isNotificationsEnabled}
+            value={isNotificationsEnabled && isSystemNotificationsEnabled}
             trackColor={{
               true: ValueSheet.colours.secondaryColour,
               false: ValueSheet.colours.purple,
             }}
             thumbColor={
-              isNotificationsEnabled
+              isNotificationsEnabled && isSystemNotificationsEnabled
                 ? ValueSheet.colours.secondaryColour
                 : ValueSheet.colours.purple
             }
@@ -740,13 +746,13 @@ const Notifications = () => {
                   width={55}
                   height={32}
                   onValueChange={habitsToggled}
-                  value={isHabitsEnabled}
+                  value={isHabitsEnabled && isSystemNotificationsEnabled}
                   trackColor={{
                     true: ValueSheet.colours.secondaryColour,
                     false: ValueSheet.colours.purple,
                   }}
                   thumbColor={
-                    isHabitsEnabled
+                    isHabitsEnabled && isSystemNotificationsEnabled
                       ? ValueSheet.colours.secondaryColour
                       : ValueSheet.colours.purple
                   }
@@ -760,13 +766,13 @@ const Notifications = () => {
                   width={55}
                   height={32}
                   onValueChange={tasksToggled}
-                  value={isTasksEnabled}
+                  value={isTasksEnabled && isSystemNotificationsEnabled}
                   trackColor={{
                     true: ValueSheet.colours.secondaryColour,
                     false: ValueSheet.colours.purple,
                   }}
                   thumbColor={
-                    isTasksEnabled
+                    isTasksEnabled && isSystemNotificationsEnabled
                       ? ValueSheet.colours.secondaryColour
                       : ValueSheet.colours.purple
                   }
@@ -788,13 +794,13 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={breakfastToggled}
-                    value={isBreakfastEnabled}
+                    value={isBreakfastEnabled && isSystemNotificationsEnabled}
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
                     }}
                     thumbColor={
-                      isBreakfastEnabled
+                      isBreakfastEnabled && isSystemNotificationsEnabled
                         ? ValueSheet.colours.secondaryColour
                         : ValueSheet.colours.purple
                     }
@@ -854,13 +860,13 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={lunchToggled}
-                    value={isLunchEnabled}
+                    value={isLunchEnabled && isSystemNotificationsEnabled}
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
                     }}
                     thumbColor={
-                      isLunchEnabled
+                      isLunchEnabled && isSystemNotificationsEnabled
                         ? ValueSheet.colours.secondaryColour
                         : ValueSheet.colours.purple
                     }
@@ -920,13 +926,13 @@ const Notifications = () => {
                     width={55}
                     height={32}
                     onValueChange={dinnerToggled}
-                    value={isDinnerEnabled}
+                    value={isDinnerEnabled && isSystemNotificationsEnabled}
                     trackColor={{
                       true: ValueSheet.colours.secondaryColour,
                       false: ValueSheet.colours.purple,
                     }}
                     thumbColor={
-                      isDinnerEnabled
+                      isDinnerEnabled && isSystemNotificationsEnabled
                         ? ValueSheet.colours.secondaryColour
                         : ValueSheet.colours.purple
                     }
@@ -996,7 +1002,9 @@ const Notifications = () => {
                 title="Wellness check-in"
                 body="It's time to check in with yourself"
                 notifications={moodNotifications}
-                isToggled={isWellnessCheckinToggled}
+                isToggled={
+                  isWellnessCheckinToggled && isSystemNotificationsEnabled
+                }
                 toggled={wellnessCheckinToggled}
                 setIsToggled={setIsWellnessCheckinToggled}
                 group="mood"
@@ -1008,7 +1016,9 @@ const Notifications = () => {
                   title="Sleep review"
                   body="Time to wake up amd review your sleep"
                   notifications={morningNotifications}
-                  isToggled={isMorningAlarmToggled}
+                  isToggled={
+                    isMorningAlarmToggled && isSystemNotificationsEnabled
+                  }
                   toggled={morningAlarmToggled}
                   setIsToggled={setIsMorningAlarmToggled}
                   group="morning"

--- a/mobile-app/src/screens/Settings/Notifications/index.js
+++ b/mobile-app/src/screens/Settings/Notifications/index.js
@@ -1005,7 +1005,7 @@ const Notifications = () => {
                 isToggled={
                   isWellnessCheckinToggled && isSystemNotificationsEnabled
                 }
-                toggled={wellnessCheckinToggled}
+                toggledHandler={wellnessCheckinToggled}
                 setIsToggled={setIsWellnessCheckinToggled}
                 group="mood"
               />
@@ -1019,7 +1019,7 @@ const Notifications = () => {
                   isToggled={
                     isMorningAlarmToggled && isSystemNotificationsEnabled
                   }
-                  toggled={morningAlarmToggled}
+                  toggledHandler={morningAlarmToggled}
                   setIsToggled={setIsMorningAlarmToggled}
                   group="morning"
                 />

--- a/mobile-app/src/screens/Settings/Notifications/soultification.js
+++ b/mobile-app/src/screens/Settings/Notifications/soultification.js
@@ -23,6 +23,7 @@ const Soultification = ({
   isToggled,
   toggledHandler,
   setIsToggled,
+  disabled,
   group,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -471,6 +472,7 @@ const Soultification = ({
             height={32}
             onValueChange={onToggle}
             value={isToggled}
+            disabled={disabled}
             trackColor={{
               true: ValueSheet.colours.secondaryColour,
               false: ValueSheet.colours.purple,

--- a/mobile-app/src/screens/Settings/Notifications/soultification.js
+++ b/mobile-app/src/screens/Settings/Notifications/soultification.js
@@ -21,7 +21,7 @@ const Soultification = ({
   body,
   notifications,
   isToggled,
-  toggled,
+  toggledHandler,
   setIsToggled,
   group,
 }) => {
@@ -233,7 +233,7 @@ const Soultification = ({
         });
       }
     }
-    var listOfExpoIDs = await toggled(notificationTriggers, turnOn);
+    var listOfExpoIDs = await toggledHandler(notificationTriggers, turnOn);
     if (listOfExpoIDs) {
       for (var i = 0; i < listOfExpoIDs.length; i++) {
         if (i == 0) {


### PR DESCRIPTION
Added a new variable to represent system notifications status. And disable all toggles when false. User will have to refresh page to see this reflected.

@KarinP03 could you update the toast messages to notify the user of this?

/*UPdate*/

See video for behaviour:
https://drive.google.com/file/d/1ABDPYZyyCji2uldkQSuKpSW7EwEeLnT2/view?usp=drive_link
