### PR TITLE
Adding setColorScheme to theme initialization

### DIFF
--- a/mobile-app/src/contexts/ThemeProvider.js
+++ b/mobile-app/src/contexts/ThemeProvider.js
@@ -12,6 +12,7 @@ export const ThemeProvider = ({ children }) => {
     const initializeTheme = async () => {
       const colorScheme = await AsyncStorage.getItem("theme");
       if (colorScheme && (colorScheme == "light" || colorScheme == "dark")) {
+        Appearance.setColorScheme(colorScheme);
         setTheme(colorScheme);
       }
     };


### PR DESCRIPTION
As the title implies, this should ensure all alerts are in the correct colour scheme when the app starts.

Video of an alert right after logging in (without manually changing the theme):

https://github.com/user-attachments/assets/1e3173bd-88b9-4992-97b9-6beea46cfc77

