### PR TITLE
Added endpoints missing from file for future testing

### DIFF
--- a/backend/rest.http
+++ b/backend/rest.http
@@ -418,6 +418,17 @@ DELETE https://8svmwrf55j.execute-api.ca-central-1.amazonaws.com/dev/v1/foodItem
 Authorization: Bearer token
 ###
 
+//get recent food entries
+Get https://8svmwrf55j.execute-api.ca-central-1.amazonaws.com/dev/v1/foodEntries/recent
+Authorization: Bearer token
+###
+
+//------------D I E T   S T A T S------------
+//-------------------------------------------
+//get diet stats food entries
+Get https://8svmwrf55j.execute-api.ca-central-1.amazonaws.com/dev/v1/dietStats?sunday=20250720
+Authorization: Bearer token
+###
 
 
 //----------F O O D   E N T R I E S----------


### PR DESCRIPTION
This contains endpoints previously missing from `rest.http` to ensure proper usage of the endpoints is clear. These were used for testing the endpoints when developing and was missed in the respective PR's as it was in the git ignore list. 